### PR TITLE
Add agent setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Workspace Agent Instructions
+
+This repository uses the Codex agent to set up the environment. To install all core packages required by the stack, run the following commands in the workspace shell:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y nodejs npm qemu-system-x86 qemu-kvm wine gstreamer1.0-tools pulseaudio kubectl docker.io tcpdump
+cd backend && npm install && cd ..
+cd frontend && npm install && cd ..
+```
+
+These steps should be executed before running any tests or development servers.

--- a/STACK.md
+++ b/STACK.md
@@ -1,0 +1,14 @@
+# Stack Requirements and Dependencies
+
+The repository relies on the following tools and libraries:
+
+- **Emulation**: `QEMU`, `PCem`, `Wine`
+- **Streaming**: `GStreamer`, `PulseAudio`
+- **Web UI**: `React`, `Tailwind CSS`, `WebRTC`, `framer-motion`, `vite`
+- **Backend**: `Node.js`, `express`
+- **Infrastructure**: `Docker`, `Helm`, `k3s` (Kubernetes)
+- **Testing and utilities**: `kubectl`, `tcpdump`, `bash`
+
+Node package dependencies are defined in `backend/package.json` and `frontend/package.json`.
+
+See `AGENTS.md` for instructions on installing the core packages in this workspace.


### PR DESCRIPTION
## Summary
- replace workdown install script with `AGENTS.md`
- reference new agent instructions from `STACK.md`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c4e476e088330bfd310cd70d028ce