### PR TITLE
Frontend loads config and adds WebRTC hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+backend/node_modules/
+frontend/node_modules/
+*.log
+package-lock.json

--- a/config/webrtc.json
+++ b/config/webrtc.json
@@ -1,0 +1,3 @@
+{
+  "iceServers": []
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,40 +1,87 @@
-import React, { useState } from 'react';
-import { motion } from 'framer-motion';
-// import { useHotkeys } from 'react-hotkeys-hook';
+import React, { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import useWebRTC from "./hooks/useWebRTC";
 
-const instances = [
-  // ...import from config/instances.json in real app
-  { id: 'instance-0', streamUrl: 'http://localhost:6080/vnc0' },
-  { id: 'instance-1', streamUrl: 'http://localhost:6080/vnc1' },
-  { id: 'instance-2', streamUrl: 'http://localhost:6080/vnc2' },
-  { id: 'instance-3', streamUrl: 'http://localhost:6080/vnc3' },
-  { id: 'instance-4', streamUrl: 'http://localhost:6080/vnc4' },
-  { id: 'instance-5', streamUrl: 'http://localhost:6080/vnc5' },
-  { id: 'instance-6', streamUrl: 'http://localhost:6080/vnc6' },
-  { id: 'instance-7', streamUrl: 'http://localhost:6080/vnc7' },
-  { id: 'instance-8', streamUrl: 'http://localhost:6080/vnc8' },
-];
-
+// Main dashboard component showing the 3×3 grid of instances
 export default function App() {
+  const [instances, setInstances] = useState([]);
+  const [hotkeys, setHotkeys] = useState({});
   const [active, setActive] = useState(0);
   const [zoom, setZoom] = useState(1);
 
-  // TODO: Wire up hotkeys for focus/zoom
+  // Fetch instance list and hotkey mapping from the backend
+  useEffect(() => {
+    fetch("/api/config/instances")
+      .then((r) => r.json())
+      .then(setInstances)
+      .catch(() => {});
+    fetch("/api/config/hotkeys")
+      .then((r) => r.json())
+      .then(setHotkeys)
+      .catch(() => {});
+  }, []);
+
+  // Register global hotkeys for focus, zoom and switching instances
+  useEffect(() => {
+    function handler(e) {
+      const parts = [];
+      if (e.ctrlKey) parts.push("Ctrl");
+      if (e.altKey) parts.push("Alt");
+      if (e.shiftKey) parts.push("Shift");
+      const key = e.key.length === 1 ? e.key : e.key;
+      parts.push(key);
+      const combo = parts.join("+");
+      if (hotkeys.focus && hotkeys.focus[combo]) {
+        const id = hotkeys.focus[combo];
+        const idx = instances.findIndex((i) => i.id === id);
+        if (idx >= 0) setActive(idx);
+      } else if (hotkeys.zoom && hotkeys.zoom[combo]) {
+        if (hotkeys.zoom[combo] === "zoom-in")
+          setZoom((z) => Math.min(z + 0.1, 2));
+        if (hotkeys.zoom[combo] === "zoom-out")
+          setZoom((z) => Math.max(z - 0.1, 0.5));
+      } else if (hotkeys.switch && hotkeys.switch[combo]) {
+        if (hotkeys.switch[combo] === "next-instance") {
+          setActive((a) => (a + 1) % instances.length);
+        }
+      }
+    }
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [hotkeys, instances]);
 
   return (
     <div className="min-h-screen bg-gray-900 flex items-center justify-center">
       <div className="grid grid-cols-3 gap-6 w-[90vw] h-[90vh]">
-        {instances.map((inst, idx) => (
-          <motion.div
-            key={inst.id}
-            className={`border-[12px] rounded-2xl border-yellow-500 lego-style transition-transform bg-black overflow-hidden ${active === idx ? 'ring-4 ring-blue-400' : ''}`}
-            onClick={() => setActive(idx)}
-            animate={{ scale: active === idx ? zoom + 0.1 : 1 }}
-            transition={{ type: 'spring', stiffness: 300 }}
-          >
-            <iframe src={inst.streamUrl} className="w-full h-full" title={inst.id} />
-          </motion.div>
-        ))}
+        {instances.map((inst, idx) => {
+          // Each instance establishes its own WebRTC connection
+          const { videoRef, audioLevel } = useWebRTC(inst.id);
+          return (
+            <motion.div
+              key={inst.id}
+              className={`border-[12px] rounded-2xl border-yellow-500 lego-style transition-transform bg-black overflow-hidden ${active === idx ? "ring-4 ring-blue-400" : ""}`}
+              onClick={() => setActive(idx)}
+              animate={{ scale: active === idx ? zoom + 0.1 : 1 }}
+              transition={{ type: "spring", stiffness: 300 }}
+            >
+              <video
+                ref={videoRef}
+                className="w-full h-full"
+                muted
+                playsInline
+              />
+              <div
+                className="absolute bottom-2 left-2 h-2 bg-gray-700"
+                style={{ width: "80%", position: "absolute" }}
+              >
+                <div
+                  className="h-full bg-green-500"
+                  style={{ width: `${Math.round(audioLevel * 100)}%` }}
+                />
+              </div>
+            </motion.div>
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/hooks/useWebRTC.js
+++ b/frontend/src/hooks/useWebRTC.js
@@ -1,0 +1,119 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Establish a WebRTC connection for the given target instance ID.
+ * Returns a video ref and current audio level for UI binding.
+ */
+export default function useWebRTC(targetId) {
+  // <video> element that will display the incoming stream
+  const videoRef = useRef(null);
+  // simple numeric audio meter 0-1 updated from Web Audio API
+  const [audioLevel, setAudioLevel] = useState(0);
+
+  useEffect(() => {
+    if (!targetId) return;
+    // Fetch optional ICE server configuration. In a Kubernetes cluster we
+    // typically don't need external STUN/TURN servers, so this defaults to an
+    // empty array when the config isn't present.
+    fetch("/api/config/webrtc")
+      .then((r) => r.json())
+      .then((cfg) => cfg.iceServers || [])
+      .catch(() => [])
+      .then((iceServers) => {
+        const wsProto = location.protocol === "https:" ? "wss" : "ws";
+        const ws = new WebSocket(`${wsProto}://${location.host}/signal`);
+        const pc = new RTCPeerConnection({ iceServers });
+
+        let audioCtx;
+        let analyser;
+
+        const dataArr = new Uint8Array(128);
+
+        function startMeter(stream) {
+          audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+          const source = audioCtx.createMediaStreamSource(stream);
+          analyser = audioCtx.createAnalyser();
+          analyser.fftSize = 256;
+          source.connect(analyser);
+          const tick = () => {
+            if (!analyser) return;
+            analyser.getByteFrequencyData(dataArr);
+            const sum = dataArr.reduce((s, v) => s + v, 0);
+            setAudioLevel(sum / dataArr.length / 255);
+            requestAnimationFrame(tick);
+          };
+          tick();
+        }
+
+        pc.ontrack = (ev) => {
+          const [stream] = ev.streams;
+          if (videoRef.current) {
+            videoRef.current.srcObject = stream;
+            videoRef.current.play().catch(() => {});
+          }
+          if (!audioCtx) startMeter(stream);
+        };
+
+        pc.onicecandidate = ({ candidate }) => {
+          if (candidate) {
+            ws.send(
+              JSON.stringify({
+                type: "signal",
+                target: targetId,
+                data: candidate,
+              }),
+            );
+          }
+        };
+
+        ws.onopen = async () => {
+          ws.send(JSON.stringify({ type: "register" }));
+          const offer = await pc.createOffer();
+          await pc.setLocalDescription(offer);
+          ws.send(
+            JSON.stringify({
+              type: "signal",
+              target: targetId,
+              data: pc.localDescription,
+            }),
+          );
+        };
+
+        ws.onmessage = async (ev) => {
+          const msg = JSON.parse(ev.data);
+          if (msg.type === "signal" && msg.data) {
+            if (msg.data.sdp) {
+              await pc.setRemoteDescription(
+                new RTCSessionDescription(msg.data),
+              );
+              if (msg.data.type === "offer") {
+                const ans = await pc.createAnswer();
+                await pc.setLocalDescription(ans);
+                ws.send(
+                  JSON.stringify({
+                    type: "signal",
+                    target: msg.from || targetId,
+                    data: pc.localDescription,
+                  }),
+                );
+              }
+            } else if (msg.data.candidate) {
+              try {
+                await pc.addIceCandidate(new RTCIceCandidate(msg.data));
+              } catch (e) {
+                console.warn("Failed to add ICE candidate", e);
+              }
+            }
+          }
+        };
+
+        return () => {
+          ws.close();
+          pc.close();
+          if (audioCtx) audioCtx.close();
+        };
+      });
+  }, [targetId]);
+
+  return { videoRef, audioLevel };
+}


### PR DESCRIPTION
## Summary
- load instance and hotkey configs from backend
- add custom hotkey handling
- add `useWebRTC` hook for negotiating WebRTC streams and metering audio
- document key functions and use cluster-only WebRTC config

## Testing
- `npm install` *(frontend)*
- `npm install` *(backend)*
- `npm run build` *(fails: Could not resolve entry module "index.html")*
- `npm test` *(frontend & backend – fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684c6942235c8330b8c0a71e8c9cb7e8