### PR TITLE
Update emulator scripts for Win98 and better startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ backend/node_modules/
 frontend/node_modules/
 *.log
 package-lock.json
+containers/**/win98.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,10 +20,10 @@ The repository is incomplete. Use the following tasks in order to finish the pro
 
 1. **Backend Functionality** – extend `backend/server.js` with a WebSocket signaling server, serve config files, and proxy VNC/WebRTC traffic.
 2. **Frontend Enhancements** – load instance data from `config/instances.json`, implement hotkeys from `config/hotkeys.json`, and create a `useWebRTC` hook with audio meters.
-3. **Windows 95 Container Images** – provide Dockerfiles for QEMU/PCem/Wine that boot Windows 95 with Lego Loco installed, capture audio/video with PulseAudio and GStreamer, and join a shared TAP bridge LAN.
+3. **Windows 98 Container Images** – provide Dockerfiles for QEMU/PCem/Wine that boot Windows 98 with Lego Loco installed, capture audio/video with PulseAudio and GStreamer, and join a shared TAP bridge LAN.
 4. **Kubernetes Deployment** – write manifests or a Helm chart to launch nine emulator pods plus the backend, mount config as ConfigMaps, and expose each stream.
 5. **Healthy Cluster Tests** – add scripts `k8s-tests/test-network.sh` and `k8s-tests/test-broadcast.sh` and integrate them into CI.
 6. **Web Audio/Video Access** – ensure streaming pipelines allow browser access with mute, volume, and fullscreen controls.
 7. **Optional VR Interface** – prototype an A-Frame or Three.js scene showing the 3×3 grid in VR and tie controller input to backend hotkeys.
 
-Completing these tasks will yield a Windows 95 cluster that communicates over a virtual LAN and streams audio/video to the web interface.
+Completing these tasks will yield a Windows 98 cluster that communicates over a virtual LAN and streams audio/video to the web interface.

--- a/FUTURE_CODING_TASKS.md
+++ b/FUTURE_CODING_TASKS.md
@@ -17,8 +17,8 @@ This document lists the outstanding work required to make the repository fully f
 - Implement hotkeys described in `config/hotkeys.json`.
 - Add a `useWebRTC` hook to negotiate WebRTC streams and display audio meters.
 
-## 4. Windows 95 Container Images
-- Create Dockerfiles for QEMU/PCem/Wine that boot Windows 95 with Lego Loco installed.
+## 4. Windows 98 Container Images
+- Create Dockerfiles for QEMU/PCem/Wine that boot Windows 98 with Lego Loco installed.
 - Configure PulseAudio and GStreamer to capture audio/video and publish as WebRTC.
 - Ensure each container joins the same virtual LAN using TAP bridges so the games can communicate.
 
@@ -41,4 +41,4 @@ This document lists the outstanding work required to make the repository fully f
 - Prototype a simple A-Frame or Three.js scene that mirrors the 3×3 grid in VR.
 - Connect controller input to the same backend hotkeys.
 
-Each section above represents a major area of missing functionality. Completing them will yield a cluster of Windows 95 containers that communicate with each other, stream audio/video to the web interface, and are verified by automated health tests.
+Each section above represents a major area of missing functionality. Completing them will yield a cluster of Windows 98 containers that communicate with each other, stream audio/video to the web interface, and are verified by automated health tests.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ kubectl apply -f helm/loco-chart/
 # Run connectivity and game-level tests
 bash k8s-tests/test-network.sh
 
+# Configure the shared TAP bridge
+bash scripts/setup_bridge.sh
+
+# Launch a QEMU-based instance
+docker run --rm --network host --cap-add=NET_ADMIN \
+  -e TAP_IF=tap0 -e BRIDGE=loco-br \
+  -v /path/to/win98.qcow2:/images/win98.qcow2 \
+  yourrepo/qemu-loco
+
 
 ---
 

--- a/containers/pcem/Dockerfile
+++ b/containers/pcem/Dockerfile
@@ -1,0 +1,16 @@
+# Base image
+FROM ubuntu:22.04
+
+# ---- Install PCem emulator and streaming tools ----
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        pcem pulseaudio \
+        gstreamer1.0-tools gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
+        x11-utils xdotool && \
+    rm -rf /var/lib/apt/lists/*
+
+# ---- Copy entrypoint ----
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/containers/pcem/entrypoint.sh
+++ b/containers/pcem/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BRIDGE=${BRIDGE:-loco-br}
+TAP_IF=${TAP_IF:-tap0}
+DISK=${DISK:-/images/win98.img}
+
+# Wait until an X11 window matching a name appears
+wait_for_window() {
+  local name=$1
+  for _ in {1..30}; do
+    if xdotool search --name "$name" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "⚠️  Timed out waiting for window $name" >&2
+}
+
+pulseaudio --start --exit-idle-time=-1
+echo "🔈 PulseAudio started"
+
+ip tuntap add "$TAP_IF" mode tap || true
+ip link set "$TAP_IF" up
+if ip link show "$BRIDGE" &>/dev/null; then
+  ip link set "$TAP_IF" master "$BRIDGE"
+fi
+
+pcem --config /pcem.cfg --hda "$DISK" &
+EMU_PID=$!
+
+# Wait for the PCem window instead of sleeping
+wait_for_window "PCem"
+
+gst-launch-1.0 -v \
+  ximagesrc use-damage=0 ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay ! application/x-rtp,media=video,encoding-name=VP8,payload=96 ! webrtcbin bundle-policy=max-bundle name=wb \
+  pulsesrc ! audioconvert ! audioresample ! opusenc ! rtpopuspay ! application/x-rtp,media=audio,encoding-name=OPUS,payload=97 ! wb. \
+  wb. ! fakesink
+
+wait $EMU_PID

--- a/containers/qemu/Dockerfile
+++ b/containers/qemu/Dockerfile
@@ -1,0 +1,16 @@
+# Base image
+FROM ubuntu:22.04
+
+# ---- Install emulator and media tools ----
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        qemu-system-x86 pulseaudio \
+        gstreamer1.0-tools gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
+        x11-utils xdotool && \
+    rm -rf /var/lib/apt/lists/*
+
+# ---- Copy entrypoint ----
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/containers/qemu/entrypoint.sh
+++ b/containers/qemu/entrypoint.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BRIDGE=${BRIDGE:-loco-br}
+TAP_IF=${TAP_IF:-tap0}
+DISK=${DISK:-/images/win98.qcow2}
+
+# Wait until an X11 window matching a name appears
+wait_for_window() {
+  local name=$1
+  for _ in {1..30}; do
+    if xdotool search --name "$name" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "⚠️  Timed out waiting for window $name" >&2
+}
+
+
+# Start PulseAudio daemon
+pulseaudio --start --exit-idle-time=-1
+echo "🔈 PulseAudio started"
+
+ip tuntap add "$TAP_IF" mode tap || true
+ip link set "$TAP_IF" up
+if ip link show "$BRIDGE" &>/dev/null; then
+  ip link set "$TAP_IF" master "$BRIDGE"
+fi
+
+echo "🌐 TAP $TAP_IF attached to $BRIDGE"
+
+qemu-system-i386 \
+  -m 256 -hda "$DISK" \
+  -net nic,model=ne2k_pci -net tap,ifname=$TAP_IF,script=no,downscript=no \
+  -vga cirrus -display sdl \
+  -audiodev pa,id=snd0 \
+  -rtc base=localtime &
+EMU_PID=$!
+
+# Wait for the QEMU window to appear instead of a fixed sleep
+wait_for_window "QEMU"
+
+gst-launch-1.0 -v \
+  ximagesrc use-damage=0 ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay ! application/x-rtp,media=video,encoding-name=VP8,payload=96 ! webrtcbin bundle-policy=max-bundle name=wb \
+  pulsesrc ! audioconvert ! audioresample ! opusenc ! rtpopuspay ! application/x-rtp,media=audio,encoding-name=OPUS,payload=97 ! wb. \
+  wb. ! fakesink
+
+wait $EMU_PID

--- a/containers/wine/Dockerfile
+++ b/containers/wine/Dockerfile
@@ -1,0 +1,16 @@
+# Base image
+FROM ubuntu:22.04
+
+# ---- Enable i386 and install Wine with streaming tools ----
+RUN dpkg --add-architecture i386 && apt-get update && \
+    apt-get install -y --no-install-recommends \
+        wine winbind pulseaudio \
+        gstreamer1.0-tools gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
+        x11-utils xdotool && \
+    rm -rf /var/lib/apt/lists/*
+
+# ---- Copy entrypoint ----
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/containers/wine/entrypoint.sh
+++ b/containers/wine/entrypoint.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BRIDGE=${BRIDGE:-loco-br}
+TAP_IF=${TAP_IF:-tap0}
+APP=${APP:-/opt/lego-loco/lego.exe}
+
+# Wait until an X11 window matching a name appears
+wait_for_window() {
+  local name=$1
+  for _ in {1..30}; do
+    if xdotool search --name "$name" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "⚠️  Timed out waiting for window $name" >&2
+}
+
+pulseaudio --start --exit-idle-time=-1
+echo "🔈 PulseAudio started"
+
+ip tuntap add "$TAP_IF" mode tap || true
+ip link set "$TAP_IF" up
+if ip link show "$BRIDGE" &>/dev/null; then
+  ip link set "$TAP_IF" master "$BRIDGE"
+fi
+
+# Start Wine application
+wine "$APP" &
+EMU_PID=$!
+
+# Wait for the game window instead of a fixed sleep
+wait_for_window "Lego Loco"
+
+gst-launch-1.0 -v \
+  ximagesrc use-damage=0 ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay ! application/x-rtp,media=video,encoding-name=VP8,payload=96 ! webrtcbin bundle-policy=max-bundle name=wb \
+  pulsesrc ! audioconvert ! audioresample ! opusenc ! rtpopuspay ! application/x-rtp,media=audio,encoding-name=OPUS,payload=97 ! wb. \
+  wb. ! fakesink
+
+wait $EMU_PID

--- a/scripts/setup_bridge.sh
+++ b/scripts/setup_bridge.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# scripts/setup_bridge.sh -- configure shared TAP bridge for emulator containers
+set -euo pipefail
+
+BRIDGE=${1:-loco-br}
+SUBNET=${2:-192.168.10.0/24}
+BRIDGE_ADDR=${3:-192.168.10.1/24}
+COUNT=${4:-9}
+
+sudo ip link add name "$BRIDGE" type bridge || true
+sudo ip addr add "$BRIDGE_ADDR" dev "$BRIDGE" 2>/dev/null || true
+sudo ip link set "$BRIDGE" up
+
+for i in $(seq 0 $((COUNT-1))); do
+  IF="tap${i}"
+  sudo ip tuntap add "$IF" mode tap 2>/dev/null || true
+  sudo ip link set "$IF" master "$BRIDGE"
+  sudo ip link set "$IF" up
+done
+
+echo "Bridge $BRIDGE with $COUNT TAP interfaces configured"


### PR DESCRIPTION
## Summary
- switch container references from Win95 to Win98
- comment Dockerfiles and install xdotool for window detection
- wait for emulator windows instead of using fixed sleep
- update docs and tasks to mention Windows 98

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_684c71a9a9088330afe0c69984a706c3