### PR TITLE
Add Helm and kustomize configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ loco-lan/
 🚦 How to Deploy
 
 # Build multi-arch Docker images
-docker buildx build --platform linux/amd64,linux/arm64 -t yourrepo/loco:latest --push .
+export LOCO_REPO=myrepo
+docker buildx build --platform linux/amd64,linux/arm64 -t $LOCO_REPO/loco:latest --push .
 
 # Create K8s cluster (k3s or kubeadm)
-kubectl apply -f helm/loco-chart/
+helm install loco helm/loco-chart --set imageRepo=$LOCO_REPO
 
 # Run connectivity and game-level tests
 bash k8s-tests/test-network.sh
@@ -73,7 +74,7 @@ bash scripts/setup_bridge.sh
 docker run --rm --network host --cap-add=NET_ADMIN \
   -e TAP_IF=tap0 -e BRIDGE=loco-br \
   -v /path/to/win98.qcow2:/images/win98.qcow2 \
-  yourrepo/qemu-loco
+  $LOCO_REPO/qemu-loco
 
 
 ---

--- a/helm/loco-chart/Chart.yaml
+++ b/helm/loco-chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: loco
+version: 0.1.0
+appVersion: "1.0"
+description: Lego Loco emulator cluster

--- a/helm/loco-chart/templates/_helpers.tpl
+++ b/helm/loco-chart/templates/_helpers.tpl
@@ -1,0 +1,19 @@
+{{- define "loco.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "loco.namespace" -}}
+{{- default .Values.namespace .Release.Namespace -}}
+{{- end -}}
+
+{{- define "loco.image" -}}
+{{- $root := .root -}}
+{{- $image := .image -}}
+{{- $tag := .tag | default "latest" -}}
+{{- $repo := $root.Values.imageRepo | default "" -}}
+{{- if $repo -}}
+{{- $repo | trimSuffix "/" }}/{{ $image }}:{{ $tag }}
+{{- else -}}
+{{- $image }}:{{ $tag }}
+{{- end -}}
+{{- end -}}

--- a/helm/loco-chart/templates/backend-deployment.yaml
+++ b/helm/loco-chart/templates/backend-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "loco.fullname" . }}-backend
+  namespace: {{ include "loco.namespace" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "loco.fullname" . }}-backend
+  template:
+    metadata:
+      labels:
+        app: {{ include "loco.fullname" . }}-backend
+    spec:
+      containers:
+      - name: backend
+        image: {{ include "loco.image" (dict "root" . "image" .Values.backend.image "tag" .Values.backend.tag) }}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: {{ .Values.backend.servicePort }}
+        volumeMounts:
+        - name: config
+          mountPath: /app/config
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "loco.fullname" . }}-instances

--- a/helm/loco-chart/templates/backend-service.yaml
+++ b/helm/loco-chart/templates/backend-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loco.fullname" . }}-backend
+  namespace: {{ include "loco.namespace" . }}
+spec:
+  type: NodePort
+  selector:
+    app: {{ include "loco.fullname" . }}-backend
+  ports:
+  - name: http
+    port: {{ .Values.backend.servicePort }}
+    targetPort: {{ .Values.backend.servicePort }}

--- a/helm/loco-chart/templates/configmap-instances.yaml
+++ b/helm/loco-chart/templates/configmap-instances.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "loco.fullname" . }}-instances
+  namespace: {{ include "loco.namespace" . }}
+data:
+  instances.json: |
+    [
+    {{- $name := include "loco.fullname" . }}
+    {{- $replicas := int .Values.replicas }}
+    {{- range $i := until $replicas }}
+      { "id": "instance-{{ $i }}", "streamUrl": "http://{{ $name }}-emulator-{{ $i }}:{{ $.Values.emulator.servicePort }}" }{{ if lt (add1 $i) $replicas }},{{ end }}
+    {{- end }}
+    ]

--- a/helm/loco-chart/templates/emulator-service.yaml
+++ b/helm/loco-chart/templates/emulator-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loco.fullname" . }}-emulator
+  namespace: {{ include "loco.namespace" . }}
+spec:
+  clusterIP: None
+  selector:
+    app: {{ include "loco.fullname" . }}-emulator
+  ports:
+  - name: vnc
+    port: {{ .Values.emulator.servicePort }}
+    targetPort: {{ .Values.emulator.servicePort }}

--- a/helm/loco-chart/templates/emulator-statefulset.yaml
+++ b/helm/loco-chart/templates/emulator-statefulset.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "loco.fullname" . }}-emulator
+  namespace: {{ include "loco.namespace" . }}
+spec:
+  serviceName: {{ include "loco.fullname" . }}-emulator
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ include "loco.fullname" . }}-emulator
+  template:
+    metadata:
+      labels:
+        app: {{ include "loco.fullname" . }}-emulator
+    spec:
+      containers:
+      - name: emulator
+        image: {{ include "loco.image" (dict "root" . "image" .Values.emulator.image "tag" .Values.emulator.tag) }}
+        imagePullPolicy: {{ .Values.emulator.imagePullPolicy }}
+        ports:
+        - containerPort: {{ .Values.emulator.servicePort }}

--- a/helm/loco-chart/templates/frontend-deployment.yaml
+++ b/helm/loco-chart/templates/frontend-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "loco.fullname" . }}-frontend
+  namespace: {{ include "loco.namespace" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "loco.fullname" . }}-frontend
+  template:
+    metadata:
+      labels:
+        app: {{ include "loco.fullname" . }}-frontend
+    spec:
+      containers:
+      - name: frontend
+        image: {{ include "loco.image" (dict "root" . "image" .Values.frontend.image "tag" .Values.frontend.tag) }}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: {{ .Values.frontend.servicePort }}
+        volumeMounts:
+        - name: config
+          mountPath: /usr/share/nginx/html/config
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "loco.fullname" . }}-instances

--- a/helm/loco-chart/templates/frontend-service.yaml
+++ b/helm/loco-chart/templates/frontend-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loco.fullname" . }}-frontend
+  namespace: {{ include "loco.namespace" . }}
+spec:
+  type: NodePort
+  selector:
+    app: {{ include "loco.fullname" . }}-frontend
+  ports:
+  - name: http
+    port: {{ .Values.frontend.servicePort }}
+    targetPort: {{ .Values.frontend.servicePort }}

--- a/helm/loco-chart/values.yaml
+++ b/helm/loco-chart/values.yaml
@@ -1,0 +1,20 @@
+replicas: 3
+namespace: loco
+
+imageRepo: ""
+
+emulator:
+  image: qemu-loco
+  tag: latest
+  imagePullPolicy: IfNotPresent
+  servicePort: 6080
+
+backend:
+  image: loco-backend
+  tag: latest
+  servicePort: 3001
+
+frontend:
+  image: loco-frontend
+  tag: latest
+  servicePort: 3000

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -1,0 +1,13 @@
+# Kustomize Setup
+
+Use the base configuration for a small cluster of three emulators:
+
+```bash
+kubectl apply -k kustomize/base
+```
+
+For a full nine node deployment:
+
+```bash
+kubectl apply -k kustomize/overlays/full
+```

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+helmCharts:
+  - name: loco
+    releaseName: loco
+    namespace: loco
+    path: ../../helm/loco-chart
+    valuesInline:
+      replicas: 3

--- a/kustomize/overlays/full/kustomization.yaml
+++ b/kustomize/overlays/full/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+
+helmCharts:
+  - name: loco
+    releaseName: loco
+    namespace: loco-prod
+    path: ../../../helm/loco-chart
+    valuesInline:
+      replicas: 9


### PR DESCRIPTION
## Summary
- create Helm chart for Lego Loco cluster
- generate emulator instance ConfigMap
- add services and deployments
- provide kustomize base and production overlay
- update repo image references
- parameterize container repository URL

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y nodejs npm qemu-system-x86 qemu-kvm wine gstreamer1.0-tools pulseaudio docker.io tcpdump`
- `cd backend && npm install`
- `cd frontend && npm install`


------
https://chatgpt.com/codex/tasks/task_b_684c77e0d02883308b9c533bf31e676e