### PR TITLE
Add TCP and websocket connectivity tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y nodejs npm qemu-system-x86 qemu-kvm wine gstreamer1.0-tools pulseaudio docker.io tcpdump netcat-openbsd
+      - name: Install Node dependencies
+        run: |
+          cd backend && npm install && cd ..
+          cd frontend && npm install && cd ..
+      - uses: helm/kind-action@v1.9.0
+        with:
+          version: v0.22.0
+      - name: Run network tests
+        run: bash k8s-tests/test-network.sh
+      - name: Run TCP tests
+        run: bash k8s-tests/test-tcp.sh
+      - name: Run broadcast tests
+        run: bash k8s-tests/test-broadcast.sh
+      - name: Run websocket tests
+        run: bash k8s-tests/test-websocket.sh
+      - name: Upload test logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: k8s-test-logs
+          path: k8s-tests/logs

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ helm install loco helm/loco-chart --set imageRepo=$LOCO_REPO
 
 # Run connectivity and game-level tests
 bash k8s-tests/test-network.sh
+bash k8s-tests/test-tcp.sh
+bash k8s-tests/test-broadcast.sh
+bash k8s-tests/test-websocket.sh
+# Logs for each test are written under k8s-tests/logs
 
 # Configure the shared TAP bridge
 bash scripts/setup_bridge.sh

--- a/k8s-tests/test-broadcast.sh
+++ b/k8s-tests/test-broadcast.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# k8s-tests/test-broadcast.sh -- confirm game sessions are visible across containers
+set -euo pipefail
+
+LOG_DIR=${LOG_DIR:-k8s-tests/logs}
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/test-broadcast.log"
+log() { echo "[$(date '+%Y-%m-%dT%H:%M:%S%z')] $*"; }
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+PORT=${PORT:-2242}
+PODS=( $(kubectl get pods -o name 2>/dev/null || true) )
+
+if [ ${#PODS[@]} -le 1 ]; then
+  log "Not enough pods for broadcast test"
+  exit 0
+fi
+
+# Ensure tcpdump exists in pods
+if ! kubectl exec "${PODS[0]}" -- which tcpdump >/dev/null 2>&1; then
+  log "tcpdump not available in pods; skipping broadcast test"
+  exit 0
+fi
+
+fail=0
+
+log "Starting listeners..."
+for pod in "${PODS[@]}"; do
+  log "Listening in $pod"
+  kubectl exec "$pod" -- sh -c "rm -f /tmp/bcast.log; timeout 10s tcpdump -n -i any udp port $PORT > /tmp/bcast.log &" >/dev/null
+done
+sleep 2
+
+log "Sending broadcast packets..."
+for pod in "${PODS[@]}"; do
+  log "Broadcasting from $pod"
+  kubectl exec "$pod" -- sh -c "echo loco | nc -b -u 255.255.255.255 $PORT" || true
+  sleep 1
+done
+sleep 5
+
+log "Checking results..."
+for pod in "${PODS[@]}"; do
+  if kubectl exec "$pod" -- grep -q "loco" /tmp/bcast.log >/dev/null 2>&1; then
+    log "  $pod received broadcast"
+  else
+    log "  $pod did NOT receive broadcast"
+    fail=1
+  fi
+  kubectl exec "$pod" -- rm -f /tmp/bcast.log >/dev/null 2>&1 || true
+done
+
+if [ $fail -eq 0 ]; then
+  log "✅ Broadcast test passed"
+else
+  log "❌ Broadcast test failed"
+  exit 1
+fi

--- a/k8s-tests/test-network.sh
+++ b/k8s-tests/test-network.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# k8s-tests/test-network.sh -- verify L2/L3 connectivity between all pods and host
+set -euo pipefail
+
+LOG_DIR=${LOG_DIR:-k8s-tests/logs}
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/test-network.log"
+log() { echo "[$(date '+%Y-%m-%dT%H:%M:%S%z')] $*"; }
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+PODS=(
+  $(kubectl get pods -o name 2>/dev/null || true)
+)
+
+if [ ${#PODS[@]} -eq 0 ]; then
+  log "No pods found, skipping network test"
+  exit 0
+fi
+
+HOST_IP=$(ip route get 1 | awk '{print $(NF-2); exit}')
+
+fail=0
+
+for pod in "${PODS[@]}"; do
+  IP=$(kubectl get "$pod" -o jsonpath='{.status.podIP}')
+  log "Host -> $pod ($IP)"
+  if ping -c1 -W1 "$IP" >/dev/null 2>&1; then
+    log "  reachable"
+  else
+    log "  FAILED"
+    fail=1
+  fi
+
+done
+
+for pod in "${PODS[@]}"; do
+  log "$pod -> host ($HOST_IP)"
+  if kubectl exec "$pod" -- ping -c1 -W1 "$HOST_IP" >/dev/null 2>&1; then
+    log "  reachable"
+  else
+    log "  FAILED"
+    fail=1
+  fi
+done
+
+for src in "${PODS[@]}"; do
+  for dst in "${PODS[@]}"; do
+    [ "$src" = "$dst" ] && continue
+    DST_IP=$(kubectl get "$dst" -o jsonpath='{.status.podIP}')
+    log "$src -> $dst ($DST_IP)"
+    if kubectl exec "$src" -- ping -c1 -W1 "$DST_IP" >/dev/null 2>&1; then
+      log "  reachable"
+    else
+      log "  FAILED"
+      fail=1
+    fi
+  done
+done
+
+if [ $fail -eq 0 ]; then
+  log "✅ Network test passed"
+else
+  log "❌ Network test failed"
+  exit 1
+fi

--- a/k8s-tests/test-tcp.sh
+++ b/k8s-tests/test-tcp.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# k8s-tests/test-tcp.sh -- verify TCP connectivity between all pods and host
+set -euo pipefail
+
+LOG_DIR=${LOG_DIR:-k8s-tests/logs}
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/test-tcp.log"
+log() { echo "[$(date '+%Y-%m-%dT%H:%M:%S%z')] $*"; }
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+PORT=${PORT:-3390}
+PODS=( $(kubectl get pods -o name 2>/dev/null || true) )
+
+if [ ${#PODS[@]} -eq 0 ]; then
+  log "No pods found, skipping TCP test"
+  exit 0
+fi
+
+HOST_IP=$(ip route get 1 | awk '{print $(NF-2); exit}')
+
+cleanup() {
+  kill $HOST_PID >/dev/null 2>&1 || true
+  for pod in "${PODS[@]}"; do
+    kubectl exec "$pod" -- sh -c "kill \$(cat /tmp/nc.pid 2>/dev/null) 2>/dev/null; rm -f /tmp/nc.pid /tmp/tcp.log" >/dev/null 2>&1 || true
+  done
+}
+trap cleanup EXIT
+
+# Start TCP listeners in pods
+for pod in "${PODS[@]}"; do
+  log "Starting listener in $pod on port $PORT"
+  kubectl exec "$pod" -- sh -c "nohup nc -l -p $PORT >/tmp/tcp.log 2>&1 & echo \$! > /tmp/nc.pid" >/dev/null
+done
+sleep 2
+
+# Start host listener
+log "Starting host listener on port $PORT"
+nc -l -p $PORT >/tmp/host_tcp.log &
+HOST_PID=$!
+sleep 1
+
+fail=0
+
+# Host -> pod
+for pod in "${PODS[@]}"; do
+  IP=$(kubectl get "$pod" -o jsonpath='{.status.podIP}')
+  log "Host TCP to $pod ($IP)"
+  if echo test | nc -w1 "$IP" $PORT >/dev/null 2>&1; then
+    log "  reachable"
+  else
+    log "  FAILED"
+    fail=1
+  fi
+done
+
+# Pod -> host
+for pod in "${PODS[@]}"; do
+  log "$pod TCP to host ($HOST_IP)"
+  if kubectl exec "$pod" -- sh -c "echo test | nc -w1 $HOST_IP $PORT" >/dev/null 2>&1; then
+    log "  reachable"
+  else
+    log "  FAILED"
+    fail=1
+  fi
+done
+
+# Pod -> pod
+for src in "${PODS[@]}"; do
+  for dst in "${PODS[@]}"; do
+    [ "$src" = "$dst" ] && continue
+    DST_IP=$(kubectl get "$dst" -o jsonpath='{.status.podIP}')
+    log "$src TCP to $dst ($DST_IP)"
+    if kubectl exec "$src" -- sh -c "echo test | nc -w1 $DST_IP $PORT" >/dev/null 2>&1; then
+      log "  reachable"
+    else
+      log "  FAILED"
+      fail=1
+    fi
+  done
+done
+
+# Cleanup handled in trap
+
+if [ $fail -eq 0 ]; then
+  log "✅ TCP test passed"
+else
+  log "❌ TCP test failed"
+  exit 1
+fi

--- a/k8s-tests/test-websocket.sh
+++ b/k8s-tests/test-websocket.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# k8s-tests/test-websocket.sh -- verify websocket and stream endpoints
+set -euo pipefail
+
+LOG_DIR=${LOG_DIR:-k8s-tests/logs}
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/test-websocket.log"
+log() { echo "[$(date '+%Y-%m-%dT%H:%M:%S%z')] $*"; }
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+BACKEND_URL=${BACKEND_URL:-http://localhost:3001}
+STREAM_CONFIG="config/instances.json"
+
+fail=0
+
+# Check backend health
+if curl -fsS "$BACKEND_URL/health" >/dev/null; then
+  log "Backend health check passed"
+else
+  log "Backend health check failed"
+  fail=1
+fi
+
+# WebSocket connectivity using backend's node_modules
+(
+  cd backend && node - "$BACKEND_URL" <<'NODE'
+const WebSocket = require('ws');
+const url = process.argv[2] + '/signal';
+const ws = new WebSocket(url);
+const timer = setTimeout(() => { console.error('timeout'); process.exit(1); }, 5000);
+ws.on('open', () => { clearTimeout(timer); ws.close(); });
+ws.on('close', () => process.exit(0));
+ws.on('error', () => process.exit(1));
+NODE
+) && log "WebSocket signal test passed" || { log "WebSocket signal test failed"; fail=1; }
+
+# Check stream URLs
+STREAMS=$(grep -o '"streamUrl": "[^"]*"' "$STREAM_CONFIG" | cut -d'"' -f4)
+for url in $STREAMS; do
+  if curl -fsS --max-time 5 -I "$url" >/dev/null; then
+    log "Stream reachable: $url"
+  else
+    log "Stream unreachable: $url"
+    fail=1
+  fi
+done
+
+if [ $fail -eq 0 ]; then
+  log "✅ WebSocket and stream test passed"
+else
+  log "❌ WebSocket and stream test failed"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- test TCP connectivity between pods and host
- verify websocket signalling and stream endpoints
- document running new tests in README
- run TCP and websocket tests in CI
- record logs for network, TCP, broadcast and websocket tests

## Testing
- `bash k8s-tests/test-network.sh`
- `bash k8s-tests/test-tcp.sh`
- `bash k8s-tests/test-broadcast.sh`
- `bash k8s-tests/test-websocket.sh`


------
https://chatgpt.com/codex/tasks/task_b_684c85d04b1c8330872c4076ce6c7b20