### PR TITLE
Update docs for easier setup

### DIFF
--- a/FUTURE_CODING_TASKS.md
+++ b/FUTURE_CODING_TASKS.md
@@ -1,44 +1,65 @@
 # Future Codex Agent Tasks for Loco LAN
 
-This document lists the outstanding work required to make the repository fully functional in a new environment. Each numbered section can be treated as a standalone prompt for a future Codex agent. Follow them in order.
+This document lists all remaining work required to accept a Windows 98 image and run the cluster reliably. Each numbered section contains a **prompt** you can copy directly into a future Codex session. Follow the steps in order.
 
-## 1. Environment Setup
-- Install required system packages as described in `AGENTS.md`.
-- Run `npm install` in both `backend/` and `frontend/`.
-- Ensure Docker and Kubernetes (k3s) are available on the target machine.
+## 0. Onboarding and Setup
+**Prompt:**
+> "Prepare the development environment for Loco LAN on a fresh Ubuntu machine. Install all required packages and initialize the repo."
 
-## 2. Backend Functionality
-- Expand `backend/server.js` to include a WebSocket signaling server.
-- Implement routes to serve configuration from `config/`.
-- Add logic to proxy VNC/WebRTC connections to the emulated machines.
+Steps:
+- Install system packages: `nodejs`, `npm`, `qemu-system-x86`, `qemu-kvm`, `wine`, `gstreamer1.0-tools`, `pulseaudio`, `docker.io`, `tcpdump`.
+- Run `npm install` inside both `backend/` and `frontend/`.
+- Ensure Docker and a Kubernetes distribution (k3s or kubeadm) are available.
 
-## 3. Frontend Enhancements
-- Replace hard-coded instance URLs in `frontend/src/App.jsx` with data loaded from `config/instances.json` via the backend.
-- Implement hotkeys described in `config/hotkeys.json`.
-- Add a `useWebRTC` hook to negotiate WebRTC streams and display audio meters.
+## 1. Image Provisioning
+**Prompt:**
+> "Create and document a Windows 98 disk image with Lego Loco installed. Provide scripts so containers can load the image automatically."
 
-## 4. Windows 98 Container Images
-- Create Dockerfiles for QEMU/PCem/Wine that boot Windows 98 with Lego Loco installed.
-- Configure PulseAudio and GStreamer to capture audio/video and publish as WebRTC.
-- Ensure each container joins the same virtual LAN using TAP bridges so the games can communicate.
+Tasks:
+- Write step-by-step instructions for installing Windows 98 and Lego Loco in an emulator.
+- Add a script that converts the install to `win98.qcow2` or `win98.img` for container use.
+- Update emulator entrypoints to read an image path from an environment variable.
 
-## 5. Kubernetes Deployment
-- Write Kubernetes manifests (or a Helm chart) to launch nine emulator pods plus the backend.
-- Mount configuration as ConfigMaps so instance addresses are discoverable.
-- Expose services so the frontend can reach each WebRTC/VNC stream.
+## 2. Persistent Storage
+**Prompt:**
+> "Modify the Helm chart so emulator pods mount the disk image from a PersistentVolumeClaim."
 
-## 6. Healthy Cluster Tests
-- Implement scripts under a new `k8s-tests/` directory:
-  - `test-network.sh` – verify L2/L3 connectivity between all pods and host.
-  - `test-broadcast.sh` – confirm game sessions are visible across containers.
-- Integrate these scripts into a CI workflow.
+Tasks:
+- Mount the image via PVC and allow configuration through `values.yaml`.
+- Add a toggle for read‑only mode so multiple pods can reuse one base image.
 
-## 7. Web Audio/Video Access
-- Extend the streaming pipeline so each emulator's audio and video are available through the browser.
-- Provide user controls for muting, volume, and fullscreen per instance.
+## 3. Cluster Bootstrap Scripts
+**Prompt:**
+> "Add helper scripts that copy the prepared disk image into the cluster and patch the Helm release automatically."
 
-## 8. VR Interface (Optional)
-- Prototype a simple A-Frame or Three.js scene that mirrors the 3×3 grid in VR.
-- Connect controller input to the same backend hotkeys.
+Tasks:
+- Create scripts to upload the image to a volume and update the release with the correct PVC.
+- Extend `scripts/start_live_cluster.sh` to call these helpers and regenerate `config/instances.json`.
 
-Each section above represents a major area of missing functionality. Completing them will yield a cluster of Windows 98 containers that communicate with each other, stream audio/video to the web interface, and are verified by automated health tests.
+## 4. Extended Test Coverage
+**Prompt:**
+> "Expand k8s-tests to verify networking and emulator boot state, and integrate the scripts into CI."
+
+Tasks:
+- Enhance `k8s-tests/test-network.sh` with ARP table checks and IPv6 connectivity.
+- Add `k8s-tests/test-boot.sh` that waits for each emulator to expose VNC and verifies the Windows desktop.
+- Run all tests in CI so failures block merges.
+
+## 5. UI/UX Polishing
+**Prompt:**
+> "Improve the frontend experience and make the streaming more resilient."
+
+Tasks:
+- Allow users to select audio output devices per instance.
+- Add reconnect logic to `useWebRTC` for dropped connections.
+- Show loading indicators while streams establish.
+
+## 6. VR Interface (Optional)
+**Prompt:**
+> "Prototype a VR scene that displays the nine video feeds and maps controller buttons to backend hotkeys."
+
+Tasks:
+- Build a basic A‑Frame scene showing the grid on a curved surface.
+- Wire VR controller events to existing backend hotkey actions.
+
+Completing these prompts will allow the repository to accept a Windows 98 + Lego Loco image and run the full cluster with stable networking, automated tests, and a polished user interface.

--- a/README.md
+++ b/README.md
@@ -22,22 +22,31 @@ Welcome to Loco LAN — a LAN-based Kubernetes system that runs 9 instances of L
 
 🚀 Future expansion to 3D VR room interface with live controls
 
+## Quick Start
 
+1. Clone this repository and enter the project directory.
+2. Run the following setup commands:
+   ```bash
+   sudo apt-get update
+   sudo apt-get install -y nodejs npm qemu-system-x86 qemu-kvm wine gstreamer1.0-tools pulseaudio docker.io tcpdump
+   cd backend && npm install && cd ..
+   cd frontend && npm install && cd ..
+   ```
+3. Ensure Docker and a Kubernetes distribution (k3s or kubeadm) are installed.
+4. Build the Docker images and deploy the Helm chart as described below.
 
 ---
 
 🛠️ Stack
 
-Layer	Tech
+Layer   Tech
 
-Emulation	QEMU, PCem, Wine
-Streaming	GStreamer, PulseAudio
-Web UI	React, Tailwind, WebRTC
-Infra	Helm, Kubernetes (k3s)
-CI/CD	GitHub Actions, Docker
-Testing	Bash, kubectl, tcpdump
-
-
+Emulation       QEMU, PCem, Wine
+Streaming       GStreamer, PulseAudio
+Web UI  React, Tailwind, WebRTC
+Infra   Helm, Kubernetes (k3s)
+CI/CD   GitHub Actions, Docker
+Testing Bash, kubectl, tcpdump
 
 ---
 
@@ -51,7 +60,6 @@ loco-lan/
 ├── k8s-tests/               # Cluster and pod health scripts
 ├── ci/                      # Build + manifest + pipeline
 └── README.md
-
 
 ---
 
@@ -80,65 +88,41 @@ docker run --rm --network host --cap-add=NET_ADMIN \
   -v /path/to/win98.qcow2:/images/win98.qcow2 \
   $LOCO_REPO/qemu-loco
 
-
 ---
-
-🧠 Agent Task Prompts (Spec-Driven)
-
-Each of the following prompts corresponds to a major task described in the project:
 
 1. 🏗️ Bootstrap React Web App (3×3 Grid UI)
 
 > Scaffold a React app using Tailwind and Vite that renders a 3×3 grid of video tiles. Each tile has zoom controls, Lego-styled borders, and a hover control panel with audio meter and fullscreen toggle.
 
-
-
 2. 🔌 Create WebRTC Hook for StreamTile
 
 > Build a useWebRTC.ts hook that connects to a signaling server, negotiates a WebRTC stream, and handles cleanup. It should support audio metering via Web Audio API and expose stats.
-
-
 
 3. 🧠 Write Signaling Server in Node.js
 
 > Create a lightweight WebSocket signaling server in Node.js using ws. It should assign stream IDs, handle SDP offer/answer exchange, and support reconnections.
 
-
-
 4. 🐳 Write Multi-Arch Dockerfiles for Emulators
 
 > Write three Dockerfiles for PCem, QEMU, and Wine environments with VNC output, PulseAudio capture, and GStreamer pipeline that exposes video+audio as WebRTC stream.
-
-
 
 5. 📦 Create Docker Manifest Workflow
 
 > Write a GitHub Actions CI workflow that builds all three Dockerfiles for both amd64 and arm64, tags them with digests, and publishes a Docker manifest list for latest.
 
-
-
 6. 🔁 Design Helm Chart with Theme Support
 
 > Create a Helm chart that defines a deployment per instance (0–8) with per-pod values for emulator type and UI border theme. Use config maps to pass per-instance style IDs.
-
-
 
 7. 🧪 Test Plan CI Job
 
 > Create a Job resource that runs test-network.sh and test-broadcast.sh after each deployment to verify L2/L3/L4 communication across pods.
 
-
-
 8. 🎮 Automate In-Game Multiplayer Detection
 
 > Write a script that connects to each VNC output, takes screenshots using vncdotool, and uses OpenCV to detect presence of LAN multiplayer game listings.
 
-
-
 9. 🎨 Lego Border Styling with SVG/CSS
 
-> Design a set of SVG patterns and Tailwind
+> Design a set of SVG patterns and Tailwind classes for Lego-style borders around the video tiles. Provide sample components demonstrating usage.
 
-
-
- 


### PR DESCRIPTION
## Summary
- flesh out future tasks with explicit prompts
- add Quick Start instructions for new developers

## Testing
- `node backend/server.js` *(smoke test)*
- `npm run build` in `frontend/`


------
https://chatgpt.com/codex/tasks/task_b_684ca3ec2ab48330b336d5bfdf207ef8