### PR TITLE
Add PVC option for emulator images

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ docker buildx build --platform linux/amd64,linux/arm64 -t $LOCO_REPO/loco:latest
 talosctl cluster create --name loco --workers=3
 talosctl kubeconfig .
 export KUBECONFIG=$PWD/kubeconfig
-helm install loco helm/loco-chart --set imageRepo=$LOCO_REPO
+helm install loco helm/loco-chart \
+  --set imageRepo=$LOCO_REPO \
+  --set emulator.diskPVC=my-disk-pvc \
+  --set emulator.diskReadOnly=true
 
 # Run connectivity and game-level tests
 bash k8s-tests/test-network.sh

--- a/helm/loco-chart/templates/emulator-statefulset.yaml
+++ b/helm/loco-chart/templates/emulator-statefulset.yaml
@@ -20,3 +20,11 @@ spec:
         imagePullPolicy: {{ .Values.emulator.imagePullPolicy }}
         ports:
         - containerPort: {{ .Values.emulator.servicePort }}
+        volumeMounts:
+        - name: disk
+          mountPath: /images
+          readOnly: {{ .Values.emulator.diskReadOnly }}
+      volumes:
+      - name: disk
+        persistentVolumeClaim:
+          claimName: {{ .Values.emulator.diskPVC }}

--- a/helm/loco-chart/values.yaml
+++ b/helm/loco-chart/values.yaml
@@ -8,6 +8,8 @@ emulator:
   tag: latest
   imagePullPolicy: IfNotPresent
   servicePort: 6080
+  diskPVC: win98-disk
+  diskReadOnly: false
 
 backend:
   image: loco-backend


### PR DESCRIPTION
## Summary
- mount emulator disk image from a configurable PVC
- allow read-only mode so replicas can share a base image
- document new Helm values in README

## Testing
- `helm lint helm/loco-chart`
- `helm template test-render helm/loco-chart`


------
https://chatgpt.com/codex/tasks/task_b_684cb99014488330bb4c3c53955f6844