### PR TITLE
Add logging to Win98 image scripts

### DIFF
--- a/docs/win98_image.md
+++ b/docs/win98_image.md
@@ -1,0 +1,59 @@
+# Building the Windows 98 + Lego Loco Disk Image
+
+This guide explains how to create a disk image that boots Windows 98 with Lego Loco pre-installed. The resulting image can be used by the emulator containers in this repository.
+
+## Prerequisites
+
+- A working PCem setup on another machine
+- Windows 98 installation ISO
+- Lego Loco game disc or installer
+- `qemu-img` installed (part of the `qemu-system-x86` package)
+
+## Steps
+
+1. **Create a new PCem machine**
+   - Configure a compatible motherboard (e.g., Intel 430VX) with 64 MB RAM.
+   - Add a blank IDE hard disk around 2 GB in size.
+   - Attach the Windows 98 ISO to the CD-ROM drive.
+
+2. **Install Windows 98**
+   - Boot the machine in PCem and follow the Windows setup prompts.
+   - When installation finishes, shut down the guest and remove the ISO.
+
+3. **Install Lego Loco**
+   - Start the machine again and insert the Lego Loco disc or mount the installer ISO.
+   - Run `SETUP.EXE` inside the guest to install the game using default options.
+   - Shut down Windows once the installation completes.
+
+4. **Export the disk image**
+   - Locate the hard disk image you created in PCem (usually a `.img` file). If
+     you already have a Windows 98 `.vhd` from another hypervisor you can use
+     that instead.
+   - Copy the disk file to your working directory on the host machine.
+
+5. **Convert the image for container use**
+   - On Linux or WSL, run the shell script below to produce `win98.img` (raw) and `win98.qcow2` (QCOW2) variants. Output is logged to `create_win98_image.log` by default:
+
+   ```bash
+   ./scripts/create_win98_image.sh /path/to/disk_image.img /desired/output/dir
+   # .img or .vhd files are supported
+   ```
+
+   - On Windows 10 install the [QEMU for Windows](https://qemu.weilnetz.de/) binaries and run the PowerShell script. Logging is also written to `create_win98_image.log`:
+
+   ```powershell
+   .\scripts\create_win98_image.ps1 C:\path\to\disk_image.img C:\output\dir
+   # Works with either .img or .vhd input
+   ```
+
+6. **Run an emulator container**
+   - Use the resulting image with the provided Dockerfiles. For example:
+
+   ```bash
+   docker run --rm --network host --cap-add=NET_ADMIN \
+     -e TAP_IF=tap0 -e BRIDGE=loco-br \
+     -v /path/to/win98.qcow2:/images/win98.qcow2 \
+     $LOCO_REPO/qemu-loco
+   ```
+
+After completing these steps the image is ready for use in the cluster.

--- a/scripts/create_win98_image.ps1
+++ b/scripts/create_win98_image.ps1
@@ -1,0 +1,53 @@
+<#
+  create_win98_image.ps1 -- Convert a PCem or VHD disk image into raw and QCOW2 formats
+  Usage: .\create_win98_image.ps1 <diskPath> [outDir]
+#>
+
+param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [string]$DiskPath,
+
+    [Parameter(Position=1)]
+    [string]$OutDir = (Get-Location)
+)
+
+$ErrorActionPreference = 'Stop'
+
+$LogFile = $env:LOG_FILE
+if (-not $LogFile) { $LogFile = 'create_win98_image.log' }
+Start-Transcript -Path $LogFile -Append | Out-Null
+
+try {
+    if (-not (Get-Command qemu-img.exe -ErrorAction SilentlyContinue)) {
+        Write-Error 'qemu-img.exe is required but was not found in PATH.'
+        exit 1
+    }
+
+    if (-not (Test-Path $DiskPath)) {
+        Write-Error "Source disk $DiskPath not found"
+        exit 1
+    }
+
+    if (-not (Test-Path $OutDir)) {
+        New-Item -ItemType Directory -Path $OutDir | Out-Null
+    }
+
+    $rawOut = Join-Path $OutDir 'win98.img'
+    $qcowOut = Join-Path $OutDir 'win98.qcow2'
+
+    $inputFmt = 'raw'
+    if ($DiskPath.ToLower().EndsWith('.vhd')) {
+        $inputFmt = 'vpc'
+    }
+
+    Write-Host "==> Converting $DiskPath to raw image $rawOut"
+    & qemu-img.exe convert -f $inputFmt -O raw $DiskPath $rawOut
+
+    Write-Host "==> Converting $DiskPath to QCOW2 image $qcowOut"
+    & qemu-img.exe convert -f $inputFmt -O qcow2 $DiskPath $qcowOut
+
+    Write-Host "Images saved in $OutDir"
+}
+finally {
+    Stop-Transcript | Out-Null
+}

--- a/scripts/create_win98_image.sh
+++ b/scripts/create_win98_image.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# create_win98_image.sh -- Convert a PCem or VHD disk into raw and QCOW2 images
+
+# Exit immediately on errors and print a helpful message
+set -euo pipefail
+trap 'echo "ERROR: command failed on line $LINENO" >&2' ERR
+
+# Optional environment variable to capture verbose logs
+LOG_FILE=${LOG_FILE:-create_win98_image.log}
+exec > >(tee -i "$LOG_FILE") 2>&1
+
+SRC_DISK=${1:-}
+OUT_DIR=${2:-$(pwd)}
+
+if [[ -z "$SRC_DISK" ]]; then
+  echo "Usage: $0 <disk.img|volume.vhd> [output_dir]" >&2
+  exit 1
+fi
+
+# Ensure qemu-img is available
+if ! command -v qemu-img >/dev/null; then
+  echo "qemu-img is required but not installed" >&2
+  exit 1
+fi
+
+if [[ ! -f "$SRC_DISK" ]]; then
+  echo "Source disk $SRC_DISK not found" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+RAW_OUT="$OUT_DIR/win98.img"
+QCOW_OUT="$OUT_DIR/win98.qcow2"
+
+# Determine input format for qemu-img
+INPUT_FMT="raw"
+case "${SRC_DISK##*.}" in
+  vhd|VHD)
+    INPUT_FMT="vpc"
+    ;;
+esac
+
+echo "==> Converting $SRC_DISK to raw image $RAW_OUT"
+qemu-img convert -f "$INPUT_FMT" -O raw "$SRC_DISK" "$RAW_OUT"
+
+echo "==> Converting $SRC_DISK to QCOW2 image $QCOW_OUT"
+qemu-img convert -f "$INPUT_FMT" -O qcow2 "$SRC_DISK" "$QCOW_OUT"
+
+echo "Images saved in $OUT_DIR"


### PR DESCRIPTION
## Summary
- enhance Windows 98 disk image scripts with logging and sanity checks
- document log output in the guide
- allow converting existing VHD volumes

## Testing
- `bash -n scripts/create_win98_image.sh`
- `pwsh -File scripts/create_win98_image.ps1` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d66ac6a088330be10453e2aabea8c