### PR TITLE
Handle missing hexdump

### DIFF
--- a/docs/win98_image.md
+++ b/docs/win98_image.md
@@ -1,0 +1,77 @@
+# Building the Windows 98 + Lego Loco Disk Image
+
+This guide explains how to create a disk image that boots Windows 98 with Lego Loco pre-installed. The resulting image can be used by the emulator containers in this repository.
+
+## Prerequisites
+
+- A working PCem setup on another machine
+- Windows 98 installation ISO
+- Lego Loco game disc or installer
+- `qemu-img` installed (part of `qemu-system-x86` or the Windows QEMU build)
+- `hexdump` or `od` available for verifying the boot signature (optional)
+
+## Steps
+
+1. **Create a new PCem machine**
+   - Configure a compatible motherboard (e.g., Intel 430VX) with 64 MB RAM.
+   - Add a blank IDE hard disk around 2 GB in size.
+   - Attach the Windows 98 ISO to the CD-ROM drive.
+
+2. **Install Windows 98**
+   - Boot the machine in PCem and follow the Windows setup prompts.
+   - When installation finishes, shut down the guest and remove the ISO.
+
+3. **Install Lego Loco**
+   - Start the machine again and insert the Lego Loco disc or mount the installer ISO.
+   - Run `SETUP.EXE` inside the guest to install the game using default options.
+   - Shut down Windows once the installation completes.
+
+4. **Export the disk image**
+   - Locate the hard disk image you created in PCem (usually a `.img` file). If
+     you already have a Windows 98 `.vhd` from another hypervisor you can use
+     that instead.
+   - Copy the disk file to your working directory on the host machine.
+
+5. **Convert the image for container use**
+  - On Linux or WSL, run the shell script below to produce `win98.img` (raw) and `win98.qcow2` (QCOW2) variants. The script verifies the disk's MBR signature (using `hexdump` or `od`) and logs progress to `create_win98_image.log` by default. It automatically uses `qemu-img` or `qemu-img.exe` depending on what is available:
+
+   ```bash
+   ./scripts/create_win98_image.sh /path/to/disk_image.img /desired/output/dir
+   # .img or .vhd files are supported
+   ```
+
+  - On Windows 10 install the [QEMU for Windows](https://qemu.weilnetz.de/) binaries and run the PowerShell script. It performs the same MBR check, chooses `qemu-img` or `qemu-img.exe` automatically, and writes verbose output to `create_win98_image.log`:
+
+   ```powershell
+   .\scripts\create_win98_image.ps1 C:\path\to\disk_image.img C:\output\dir
+   # Works with either .img or .vhd input
+   ```
+
+6. **Verify the QCOW2 image locally**
+   - Before packaging the image, you can boot it directly with QEMU. The example
+     below mirrors the container runtime flags and assumes `qemu-system-i386`
+     is installed. Replace `/path/to/win98.qcow2` with your QCOW2 file and set
+     `TAP_IF` to an existing TAP interface name:
+
+   ```bash
+   TAP_IF=tap0 qemu-system-i386 \
+     -m 256 -hda /path/to/win98.qcow2 \
+     -net nic,model=ne2k_pci -net tap,ifname=$TAP_IF,script=no,downscript=no \
+     -vga cirrus -display sdl \
+     -audiodev pa,id=snd0 \
+     -rtc base=localtime &
+   ```
+   
+   If the Windows 98 desktop appears the image is ready for container use.
+
+7. **Run an emulator container**
+   - Use the resulting image with the provided Dockerfiles. For example:
+
+   ```bash
+   docker run --rm --network host --cap-add=NET_ADMIN \
+     -e TAP_IF=tap0 -e BRIDGE=loco-br \
+     -v /path/to/win98.qcow2:/images/win98.qcow2 \
+     $LOCO_REPO/qemu-loco
+   ```
+
+After completing these steps the image is ready for use in the cluster.

--- a/scripts/create_win98_image.ps1
+++ b/scripts/create_win98_image.ps1
@@ -1,0 +1,67 @@
+<#
+  create_win98_image.ps1 -- Convert a PCem or VHD disk image into raw and QCOW2 formats
+  Usage: .\create_win98_image.ps1 <diskPath> [outDir]
+#>
+
+param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [string]$DiskPath,
+
+    [Parameter(Position=1)]
+    [string]$OutDir = (Get-Location)
+)
+
+$ErrorActionPreference = 'Stop'
+
+$LogFile = $env:LOG_FILE
+if (-not $LogFile) { $LogFile = 'create_win98_image.log' }
+Start-Transcript -Path $LogFile -Append | Out-Null
+
+try {
+    $qemuImg = Get-Command qemu-img -ErrorAction SilentlyContinue
+    if (-not $qemuImg) {
+        $qemuImg = Get-Command qemu-img.exe -ErrorAction SilentlyContinue
+    }
+    if (-not $qemuImg) {
+        Write-Error 'qemu-img is required but was not found in PATH.'
+        exit 1
+    }
+
+    if (-not (Test-Path $DiskPath)) {
+        Write-Error "Source disk $DiskPath not found"
+        exit 1
+    }
+
+    if (-not (Test-Path $OutDir)) {
+        New-Item -ItemType Directory -Path $OutDir | Out-Null
+    }
+
+    $rawOut = Join-Path $OutDir 'win98.img'
+    $qcowOut = Join-Path $OutDir 'win98.qcow2'
+
+    $inputFmt = 'raw'
+    if ($DiskPath.ToLower().EndsWith('.vhd')) {
+        $inputFmt = 'vpc'
+    }
+
+    Write-Host "==> Converting $DiskPath to raw image $rawOut"
+    & $qemuImg convert -p -f $inputFmt -O raw $DiskPath $rawOut
+
+    # Verify MBR signature
+    $fs = [System.IO.File]::Open($rawOut, 'Open', 'Read')
+    $fs.Seek(510, 'Begin') | Out-Null
+    $sig = New-Object byte[] 2
+    $fs.Read($sig, 0, 2) | Out-Null
+    $fs.Close()
+    if ($sig[0] -ne 0x55 -or $sig[1] -ne 0xAA) {
+        Write-Warning 'MBR signature not found; image may not be bootable.'
+    }
+
+    Write-Host "==> Converting $DiskPath to QCOW2 image $qcowOut"
+    & $qemuImg convert -p -f $inputFmt -O qcow2 -o compat=0.10 $DiskPath $qcowOut
+
+    Write-Host "Images saved in $OutDir"
+}
+finally {
+    Stop-Transcript | Out-Null
+}

--- a/scripts/create_win98_image.sh
+++ b/scripts/create_win98_image.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# create_win98_image.sh -- Convert a PCem or VHD disk into raw and QCOW2 images
+
+# Exit immediately on errors and print a helpful message
+set -euo pipefail
+trap 'echo "ERROR: command failed on line $LINENO" >&2' ERR
+
+# Optional environment variable to capture verbose logs
+LOG_FILE=${LOG_FILE:-create_win98_image.log}
+exec > >(tee -i "$LOG_FILE") 2>&1
+
+SRC_DISK=${1:-}
+OUT_DIR=${2:-$(pwd)}
+
+if [[ -z "$SRC_DISK" ]]; then
+  echo "Usage: $0 <disk.img|volume.vhd> [output_dir]" >&2
+  exit 1
+fi
+
+# Ensure qemu-img is available (works with qemu-img or qemu-img.exe)
+if command -v qemu-img >/dev/null; then
+  QEMU_IMG="$(command -v qemu-img)"
+elif command -v qemu-img.exe >/dev/null; then
+  QEMU_IMG="$(command -v qemu-img.exe)"
+else
+  echo "qemu-img is required but not installed" >&2
+  exit 1
+fi
+
+if [[ ! -f "$SRC_DISK" ]]; then
+  echo "Source disk $SRC_DISK not found" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+RAW_OUT="$OUT_DIR/win98.img"
+QCOW_OUT="$OUT_DIR/win98.qcow2"
+
+# Determine input format for qemu-img
+INPUT_FMT="raw"
+case "${SRC_DISK##*.}" in
+  vhd|VHD)
+    INPUT_FMT="vpc"
+    ;;
+esac
+
+echo "==> Converting $SRC_DISK to raw image $RAW_OUT"
+"$QEMU_IMG" convert -p -f "$INPUT_FMT" -O raw "$SRC_DISK" "$RAW_OUT"
+
+# Verify MBR signature so the disk is bootable
+CHECK_CMD=""
+if command -v hexdump >/dev/null; then
+  CHECK_CMD="hexdump -v -e '/1 \"%02x\"'"
+elif command -v od >/dev/null; then
+  CHECK_CMD="od -An -tx1"
+fi
+
+if [[ -n "$CHECK_CMD" ]]; then
+  if ! dd if="$RAW_OUT" bs=1 skip=510 count=2 2>/dev/null | eval $CHECK_CMD | tr -d ' \n' | grep -qi "55aa"; then
+    echo "WARNING: MBR signature not found; image may not be bootable." >&2
+  fi
+else
+  echo "WARNING: hexdump/od not found; skipping boot signature check." >&2
+fi
+
+echo "==> Converting $SRC_DISK to QCOW2 image $QCOW_OUT"
+"$QEMU_IMG" convert -p -f "$INPUT_FMT" -O qcow2 -o compat=0.10 "$SRC_DISK" "$QCOW_OUT"
+
+echo "Images saved in $OUT_DIR"


### PR DESCRIPTION
## Summary
- document optional hexdump/od requirement in the Windows 98 image guide
- warn if neither hexdump nor od is present when checking the MBR
- explain how to boot the QCOW2 file with QEMU for testing
- document full qemu boot command

## Testing
- `bash -n scripts/create_win98_image.sh`
- `./scripts/create_win98_image.sh` *(usage shown)*
- `pwsh -File scripts/create_win98_image.ps1` *(command not found)*
- `bash k8s-tests/test-network.sh` *(fails: kubectl not found)*
- `bash k8s-tests/test-broadcast.sh` *(fails: kubectl not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d66ac6a088330be10453e2aabea8c