### PR TITLE
Salvage #91: structured logging in k8s services, dev deploy scripts, discovery RCA

### DIFF
--- a/backend/services/instanceManager.js
+++ b/backend/services/instanceManager.js
@@ -115,7 +115,7 @@ class InstanceManager {
         if (!inst.health) inst.health = {};
 
         // Update overall health based on probe
-        console.log(`[DEBUG] Probe result for ${inst.id}:`, JSON.stringify(inst.probe));
+        logger.info(`Probe result for ${inst.id}:`, JSON.stringify(inst.probe));
 
         if (inst.probe.reachable && inst.probe.services.vnc.status === 'ok') {
           // If probe is good, trust it
@@ -123,7 +123,7 @@ class InstanceManager {
           inst.health.ready = true;
           inst.health.details = 'Active probe successful';
         } else {
-          console.log(`[DEBUG] Probe failed for ${inst.id}`, inst.probe.services.vnc.status);
+          logger.info(`Probe failed for ${inst.id}`, inst.probe.services.vnc.status);
           logger.info(`Probe failed for ${inst.id}`, {
             vnc: inst.probe.services.vnc.status,
             health: inst.probe.services.health.status,

--- a/backend/services/instanceManager.js
+++ b/backend/services/instanceManager.js
@@ -115,7 +115,7 @@ class InstanceManager {
         if (!inst.health) inst.health = {};
 
         // Update overall health based on probe
-        logger.info(`Probe result for ${inst.id}:`, JSON.stringify(inst.probe));
+        logger.debug(`Probe result for ${inst.id}`, { probe: inst.probe });
 
         if (inst.probe.reachable && inst.probe.services.vnc.status === 'ok') {
           // If probe is good, trust it
@@ -123,7 +123,6 @@ class InstanceManager {
           inst.health.ready = true;
           inst.health.details = 'Active probe successful';
         } else {
-          logger.info(`Probe failed for ${inst.id}`, inst.probe.services.vnc.status);
           logger.info(`Probe failed for ${inst.id}`, {
             vnc: inst.probe.services.vnc.status,
             health: inst.probe.services.health.status,

--- a/backend/services/kubernetesDiscovery.js
+++ b/backend/services/kubernetesDiscovery.js
@@ -118,8 +118,8 @@ class KubernetesDiscovery {
 
       const labelSelector = 'app.kubernetes.io/component=emulator,app.kubernetes.io/part-of=lego-loco-cluster';
 
-      console.log(`🚀 Calling Kubernetes APIs for namespace: "${namespace}"`);
-      console.log(`📝 Label selector: "${labelSelector}"`);
+      logger.info(`Calling Kubernetes APIs for namespace: "${namespace}"`);
+      logger.info(`Label selector: "${labelSelector}"`);
 
       // Add pre-call validation
       if (typeof namespace !== 'string') {
@@ -137,7 +137,7 @@ class KubernetesDiscovery {
         labelSelector: labelSelector
       };
 
-      console.log(`🔧 API call parameters:`, { pods: listPodsParams, statefulSets: listStatefulSetsParams });
+      logger.info(`API call parameters:`, { pods: listPodsParams, statefulSets: listStatefulSetsParams });
 
       // Execute both API calls in parallel for efficiency
       // The newer Kubernetes client expects an object with namespace and other options
@@ -152,13 +152,13 @@ class KubernetesDiscovery {
       }
 
       if (!statefulSetsResponse || !statefulSetsResponse.body) {
-        console.log('⚠️ No StatefulSets response or body from Kubernetes API');
+        logger.info('No StatefulSets response or body from Kubernetes API');
       }
 
       const pods = podsResponse.body.items || [];
       const statefulSets = statefulSetsResponse.body.items || [];
 
-      console.log(`✅ Kubernetes API responses received - found ${pods.length} pods and ${statefulSets.length} StatefulSets`);
+      logger.info(`Kubernetes API responses received - found ${pods.length} pods and ${statefulSets.length} StatefulSets`);
 
       const instances = [];
       logger.debug("Processing discovered pods", { podCount: pods.length });
@@ -209,9 +209,9 @@ class KubernetesDiscovery {
             }
           };
 
-          console.log(`✅ Added instance: ${instance.id} (${pod.metadata.name})`);
+          logger.info(`Added instance: ${instance.id} (${pod.metadata.name})`);
           if (statefulSet) {
-            console.log(`   📊 StatefulSet info: ${statefulSet.metadata.name} (${statefulSet.status.readyReplicas || 0}/${statefulSet.spec.replicas} ready)`);
+            logger.info(`   📊 StatefulSet info: ${statefulSet.metadata.name} (${statefulSet.status.readyReplicas || 0}/${statefulSet.spec.replicas} ready)`);
           }
           instances.push(instance);
           logger.debug("Instance discovered", {
@@ -279,11 +279,11 @@ class KubernetesDiscovery {
       // Ensure namespace is a valid string with extra validation, default to 'loco'
       const namespace = String(this.namespace).trim();
       if (!namespace || namespace === 'null' || namespace === 'undefined') {
-        console.warn('Namespace validation failed for services info - using default: loco');
+        logger.warn('Namespace validation failed for services info - using default: loco');
         return {};
       }
 
-      console.log(`🔍 Getting services info for namespace: "${namespace}"`);
+      logger.info(`Getting services info for namespace: "${namespace}"`);
 
       // Use object-based parameters for kubernetes/client-node v1.3.0+
       const labelSelector = 'app.kubernetes.io/part-of=lego-loco-cluster';
@@ -299,7 +299,7 @@ class KubernetesDiscovery {
         return {};
       }
 
-      console.log(`✅ Found ${servicesResponse.body.items?.length || 0} services`);
+      logger.info(`Found ${servicesResponse.body.items?.length || 0} services`);
 
       const services = {};
 
@@ -311,7 +311,7 @@ class KubernetesDiscovery {
           ports: service.spec.ports,
           selector: service.spec.selector
         };
-        console.log(`📋 Found service: ${service.metadata.name} (${service.spec.type})`);
+        logger.info(`Found service: ${service.metadata.name} (${service.spec.type})`);
       }
 
       return services;
@@ -385,7 +385,7 @@ class KubernetesDiscovery {
         }
       );
 
-      console.log(`✅ Watch established for namespace: "${namespace}"`);
+      logger.info(`Watch established for namespace: "${namespace}"`);
       return watchRequest;
     } catch (error) {
       logger.error("Failed to start watching instances", { error: error.message });
@@ -405,7 +405,7 @@ class KubernetesDiscovery {
     }
 
     if (!this.namespace || this.namespace.trim() === '' || this.namespace === 'null' || this.namespace === 'undefined') {
-      console.warn('Cannot get StatefulSets info: Kubernetes namespace is null, undefined, or empty');
+      logger.warn('Cannot get StatefulSets info: Kubernetes namespace is null, undefined, or empty');
       return {};
     }
 
@@ -413,11 +413,11 @@ class KubernetesDiscovery {
       // Ensure namespace is a valid string with extra validation, default to 'loco'
       const namespace = String(this.namespace).trim();
       if (!namespace || namespace === 'null' || namespace === 'undefined') {
-        console.warn('Namespace validation failed for StatefulSets info - using default: loco');
+        logger.warn('Namespace validation failed for StatefulSets info - using default: loco');
         return {};
       }
 
-      console.log(`🔍 Getting StatefulSets info for namespace: "${namespace}"`);
+      logger.info(`Getting StatefulSets info for namespace: "${namespace}"`);
 
       // Use object-based parameters for kubernetes/client-node v1.3.0+
       const labelSelector = 'app.kubernetes.io/part-of=lego-loco-cluster';
@@ -429,11 +429,11 @@ class KubernetesDiscovery {
       const statefulSetsResponse = await this.k8sAppsApi.listNamespacedStatefulSet(listStatefulSetsParams);
 
       if (!statefulSetsResponse || !statefulSetsResponse.body) {
-        console.log('⚠️ No StatefulSets response or body from Kubernetes API');
+        logger.info('No StatefulSets response or body from Kubernetes API');
         return {};
       }
 
-      console.log(`✅ Found ${statefulSetsResponse.body.items?.length || 0} StatefulSets`);
+      logger.info(`Found ${statefulSetsResponse.body.items?.length || 0} StatefulSets`);
 
       const statefulSets = {};
 
@@ -449,12 +449,12 @@ class KubernetesDiscovery {
           observedGeneration: sts.status.observedGeneration,
           conditions: sts.status.conditions || []
         };
-        console.log(`📋 Found StatefulSet: ${sts.metadata.name} (${sts.status.readyReplicas || 0}/${sts.spec.replicas} ready)`);
+        logger.info(`Found StatefulSet: ${sts.metadata.name} (${sts.status.readyReplicas || 0}/${sts.spec.replicas} ready)`);
       }
 
       return statefulSets;
     } catch (error) {
-      console.error('❌ Failed to get StatefulSets info:', error.message);
+      logger.error('Failed to get StatefulSets info:', error.message);
       return {};
     }
   }

--- a/backend/services/kubernetesDiscovery.js
+++ b/backend/services/kubernetesDiscovery.js
@@ -454,7 +454,7 @@ class KubernetesDiscovery {
 
       return statefulSets;
     } catch (error) {
-      logger.error('Failed to get StatefulSets info:', error.message);
+      logger.error('Failed to get StatefulSets info', { error: error.message });
       return {};
     }
   }

--- a/docs/RCA_KUBERNETES_DISCOVERY.md
+++ b/docs/RCA_KUBERNETES_DISCOVERY.md
@@ -1,0 +1,145 @@
+# Root Cause Analysis: Kubernetes Discovery API Parameter Error
+
+**Date:** 2025-08-14  
+**Status:** ACTIVE - Production blocking issue  
+**Priority:** CRITICAL  
+**Issue ID:** K8S-DISCOVERY-001  
+
+## Executive Summary
+
+Production deployment is blocked by persistent Kubernetes API parameter error in service discovery. Despite multiple clean rebuilds and source code modifications, the error "Required parameter namespace was null or undefined when calling CoreV1Api.listNamespacedPod" persists at line 70, while source code shows different API calls at line 73.
+
+## Problem Statement
+
+### Primary Issue
+- **Error:** `Required parameter namespace was null or undefined when calling CoreV1Api.listNamespacedPod`
+- **Location:** Reported at line 70 in kubernetesDiscovery.js
+- **Impact:** Production Kubernetes discovery completely non-functional
+- **Workaround:** System runs with `ALLOW_EMPTY_DISCOVERY=true` (fallback mode)
+
+### Secondary Issues
+1. **Build/Deployment Inconsistency:** Source code changes not reflected in running containers despite clean rebuilds
+2. **Line Number Mismatch:** Error reports line 70, but `listNamespacedPod` appears at line 120+ in source
+3. **Cache Persistence:** Docker/Minikube caches persist despite aggressive cleanup
+
+## Technical Context
+
+### Environment
+- **Platform:** Minikube Kubernetes cluster
+- **Backend:** Node.js with @kubernetes/client-node
+- **Deployment:** Helm chart with loco-backend:latest image
+- **Namespace:** 'loco' (detected correctly)
+- **RBAC:** Service account with proper permissions configured
+
+### Code Archaeology
+```javascript
+// Current source at line 73 (working)
+const nsResponse = await this.k8sApi.listNamespace();
+
+// Error reports this at line 70 (failing)
+await this.k8sApi.listNamespacedPod(namespace, labelSelector);
+```
+
+### API Client Evolution
+1. **Initial:** Positional parameters `listNamespacedPod(namespace, labelSelector)`
+2. **Current:** Object parameters `listNamespacedPod({ namespace, labelSelector })`
+3. **Test:** Simple connectivity test with `listNamespace()`
+
+## Root Cause Hypothesis
+
+### Primary Hypothesis: Stale Container Image
+- **Evidence:** Source shows line 73 with `listNamespace()`, error reports line 70 with `listNamespacedPod()`
+- **Mechanism:** Docker layer caching or Minikube image persistence
+- **Validation:** Multiple `--no-cache` rebuilds and minikube image cleanup attempted
+
+### Secondary Hypothesis: API Client Version Mismatch
+- **Evidence:** Parameter syntax inconsistency between documentation and actual behavior
+- **Mechanism:** @kubernetes/client-node version incompatibility
+- **Validation:** Need to verify exact version and parameter expectations
+
+### Tertiary Hypothesis: Build Context Issues
+- **Evidence:** Changes not reflected despite clean rebuilds
+- **Mechanism:** Docker build context not picking up latest source
+- **Validation:** Need to verify Dockerfile COPY commands and build context
+
+## Investigation Timeline
+
+### Attempts Made
+1. **Multiple API Syntax Changes:** Positional → Object parameters
+2. **Clean Rebuilds:** `docker build --no-cache` (5+ attempts)
+3. **Cache Cleanup:** `docker system prune -af`, `minikube ssh -- docker system prune -af`
+4. **Image Management:** `minikube image rm`, `minikube image load`
+5. **Source Verification:** Confirmed line 73 contains `listNamespace()` call
+
+### Results
+- ✅ Backend runs successfully in test mode
+- ✅ Emulator pod operational
+- ✅ Health checks passing
+- ❌ Production discovery still fails with same error
+- ❌ Line number mismatch persists
+
+## Action Plan
+
+### Immediate Actions (Next 30 minutes)
+1. **Complete Build Verification**
+   - Verify Docker build context includes latest source
+   - Check Dockerfile COPY commands
+   - Validate image layers contain expected files
+
+2. **API Client Investigation**
+   - Check @kubernetes/client-node version in package.json
+   - Verify parameter syntax for current version
+   - Test API calls in isolation
+
+3. **Deployment Pipeline Validation**
+   - Verify Helm chart uses correct image tag
+   - Check ImagePullPolicy is Always
+   - Validate Minikube image loading process
+
+### Short-term Actions (Next 2 hours)
+1. **Complete Container Rebuild**
+   - Delete all images and containers
+   - Rebuild from scratch with verification
+   - Deploy with fresh Minikube cluster if needed
+
+2. **API Client Replacement**
+   - Consider alternative Kubernetes client libraries
+   - Implement manual REST API calls as fallback
+   - Add comprehensive logging for all API calls
+
+### Contingency Plan
+If issue persists after systematic rebuild:
+1. **Implement REST API Fallback:** Direct HTTP calls to Kubernetes API
+2. **Static Configuration Override:** Use config files instead of discovery
+3. **Alternative Discovery Method:** Service mesh or external registry
+
+## Metrics and Success Criteria
+
+### Success Metrics
+- ✅ `kubectl logs` shows no API parameter errors
+- ✅ Backend discovers emulator instances via Kubernetes API
+- ✅ `ALLOW_EMPTY_DISCOVERY=false` works in production
+- ✅ Real-time pod discovery functional
+
+### Validation Tests
+1. Deploy with discovery enabled
+2. Verify instance enumeration
+3. Confirm WebRTC streaming works
+4. Test pod scaling scenarios
+
+## Next Steps
+
+1. **Execute development cycle script** (to be created)
+2. **Systematic build verification**
+3. **API client investigation**
+4. **Production deployment validation**
+
+## Updates Log
+
+### 2025-08-14 Initial Analysis
+- Documented current state and hypotheses
+- Identified build/deployment inconsistency as primary suspect
+- Established systematic investigation plan
+
+---
+**Note:** This document will be updated with each iteration until resolution. All investigation steps and results should be documented here for future reference.

--- a/docs/RCA_KUBERNETES_DISCOVERY.md
+++ b/docs/RCA_KUBERNETES_DISCOVERY.md
@@ -1,7 +1,7 @@
 # Root Cause Analysis: Kubernetes Discovery API Parameter Error
 
 **Date:** 2025-08-14  
-**Status:** ACTIVE - Production blocking issue  
+**Status:** RESOLVED — fixed on main (namespace handling rewritten in kubernetesDiscovery.js; see TASKS_ORCHESTRATION.md Task 1.1). Kept as historical RCA.  
 **Priority:** CRITICAL  
 **Issue ID:** K8S-DISCOVERY-001  
 
@@ -129,7 +129,7 @@ If issue persists after systematic rebuild:
 
 ## Next Steps
 
-1. **Execute development cycle script** (to be created)
+1. **Execute development cycle script** — `scripts/dev-cycle-deploy.sh` (full cycle) or `scripts/simple-backend-deploy.sh` (backend-only)
 2. **Systematic build verification**
 3. **API client investigation**
 4. **Production deployment validation**

--- a/scripts/dev-cycle-deploy.sh
+++ b/scripts/dev-cycle-deploy.sh
@@ -1,0 +1,517 @@
+#!/bin/bash
+# Development Cycle Deploy Script for Kubernetes Discovery Issue Resolution
+# This script provides comprehensive cleanup and deployment cycle for systematic debugging
+
+set -e  # Exit on any error
+
+# Configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+IMAGE_NAME="loco-backend"
+IMAGE_TAG="latest"
+NAMESPACE="loco"
+HELM_RELEASE="loco"
+HELM_CHART="./helm/loco-chart"
+BUILD_CONTEXT="./backend"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_section() {
+    echo -e "\n${BLUE}==== $1 ====${NC}"
+}
+
+# Check prerequisites
+check_prerequisites() {
+    log_section "Checking Prerequisites"
+    
+    # Check minikube
+    if ! command -v minikube &> /dev/null; then
+        log_error "minikube is not installed or not in PATH"
+        exit 1
+    fi
+    
+    # Check docker
+    if ! command -v docker &> /dev/null; then
+        log_error "docker is not installed or not in PATH"
+        exit 1
+    fi
+    
+    # Check helm
+    if ! command -v helm &> /dev/null; then
+        log_error "helm is not installed or not in PATH"
+        exit 1
+    fi
+    
+    # Check kubectl
+    if ! command -v kubectl &> /dev/null; then
+        log_error "kubectl is not installed or not in PATH"
+        exit 1
+    fi
+    
+    log_success "All prerequisites available"
+}
+
+# Comprehensive cleanup function
+cleanup_all() {
+    log_section "Comprehensive Cleanup"
+    
+    # Comprehensive Helm cleanup - check for multiple release names
+    log_info "Cleaning up all Helm releases..."
+    
+    # Try common release names that might conflict
+    for release in "loco-cluster" "loco" "lego-loco" "emulator"; do
+        if helm list -n "$NAMESPACE" | grep -q "$release"; then
+            log_info "Uninstalling Helm release: $release"
+            helm uninstall "$release" -n "$NAMESPACE" 2>/dev/null || log_warning "Failed to uninstall $release"
+        fi
+    done
+    
+    # Also check default namespace for releases
+    for release in "loco-cluster" "loco" "lego-loco" "emulator"; do
+        if helm list | grep -q "$release"; then
+            log_info "Uninstalling Helm release in default namespace: $release"
+            helm uninstall "$release" 2>/dev/null || log_warning "Failed to uninstall $release from default namespace"
+        fi
+    done
+    
+    # Clean up persistent volumes that might conflict
+    log_info "Cleaning up persistent volumes..."
+    kubectl get pv | grep -E "(win98|loco|emulator)" | awk '{print $1}' | while read pv; do
+        if [[ -n "$pv" && "$pv" != "NAME" ]]; then
+            log_info "Deleting persistent volume: $pv"
+            kubectl delete pv "$pv" --ignore-not-found=true || log_warning "Failed to delete PV $pv"
+        fi
+    done
+    
+    # Clean up persistent volume claims
+    log_info "Cleaning up persistent volume claims in namespace $NAMESPACE..."
+    kubectl delete pvc --all -n "$NAMESPACE" --ignore-not-found=true || log_warning "Failed to delete PVCs"
+    
+    # Kubernetes namespace cleanup
+    log_info "Cleaning up Kubernetes namespace..."
+    kubectl delete namespace "$NAMESPACE" --ignore-not-found=true
+    
+    # Wait for namespace deletion
+    log_info "Waiting for namespace deletion..."
+    while kubectl get namespace "$NAMESPACE" &> /dev/null; do
+        log_info "Waiting for namespace $NAMESPACE to be deleted..."
+        sleep 2
+    done
+    
+    # Additional cleanup for stuck resources
+    log_info "Force cleaning any stuck resources..."
+    kubectl get all --all-namespaces | grep -E "(loco|emulator)" | awk '{print $1 "/" $2}' | while read resource; do
+        if [[ -n "$resource" && "$resource" != "/" ]]; then
+            log_info "Force deleting stuck resource: $resource"
+            kubectl delete "$resource" --force --grace-period=0 2>/dev/null || log_warning "Failed to force delete $resource"
+        fi
+    done
+    
+    # Docker cleanup
+    log_info "Cleaning up Docker containers and images..."
+    docker container prune -f || log_warning "Docker container prune failed"
+    docker image prune -f || log_warning "Docker image prune failed"
+    docker system prune -f || log_warning "Docker system prune failed"
+    
+    # Remove specific images
+    log_info "Removing specific backend images..."
+    docker rmi "${IMAGE_NAME}:${IMAGE_TAG}" 2>/dev/null || log_warning "Image ${IMAGE_NAME}:${IMAGE_TAG} not found"
+    docker rmi "$(docker images -q ${IMAGE_NAME} 2>/dev/null)" 2>/dev/null || log_warning "No ${IMAGE_NAME} images found"
+    
+    # Minikube cleanup
+    log_info "Cleaning up Minikube..."
+    
+    # Remove images from minikube
+    minikube image rm "${IMAGE_NAME}:${IMAGE_TAG}" 2>/dev/null || log_warning "Image not found in minikube"
+    
+    # Clean minikube docker cache
+    log_info "Cleaning minikube docker cache..."
+    minikube ssh -- "docker container prune -f" 2>/dev/null || log_warning "Minikube container prune failed"
+    minikube ssh -- "docker image prune -f" 2>/dev/null || log_warning "Minikube image prune failed"
+    minikube ssh -- "docker system prune -af" 2>/dev/null || log_warning "Minikube system prune failed"
+    
+    # Final cleanup - remove any orphaned persistent volumes
+    log_info "Final cleanup of orphaned persistent volumes..."
+    sleep 5  # Wait for namespace deletion to propagate
+    kubectl get pv | grep -E "(Available|Released|Failed)" | grep -E "(win98|loco|emulator)" | awk '{print $1}' | while read pv; do
+        if [[ -n "$pv" && "$pv" != "NAME" ]]; then
+            log_info "Cleaning up orphaned PV: $pv"
+            kubectl patch pv "$pv" -p '{"metadata":{"finalizers":null}}' 2>/dev/null || true
+            kubectl delete pv "$pv" --ignore-not-found=true 2>/dev/null || true
+        fi
+    done
+    
+    # Check if minikube is running, if not start it
+    if ! minikube status | grep -q "Running"; then
+        log_info "Starting minikube..."
+        minikube start --driver=docker --memory=4096 --cpus=2
+    fi
+    
+    log_success "Comprehensive cleanup completed"
+}
+
+# Targeted cleanup function - focuses on backend components only
+cleanup_backend_only() {
+    log_section "Targeted Backend Cleanup"
+    
+    # Only cleanup the specific Helm release
+    log_info "Cleaning up Helm release: $HELM_RELEASE"
+    helm uninstall "$HELM_RELEASE" -n "$NAMESPACE" 2>/dev/null || log_warning "Helm release $HELM_RELEASE not found"
+    
+    # Only delete backend-related pods/deployments (keep emulators running)
+    log_info "Cleaning up backend deployments..."
+    kubectl delete deployment -l app.kubernetes.io/component=backend -n "$NAMESPACE" --ignore-not-found=true || log_warning "No backend deployments found"
+    
+    # Delete backend services
+    log_info "Cleaning up backend services..."
+    kubectl delete service -l app.kubernetes.io/component=backend -n "$NAMESPACE" --ignore-not-found=true || log_warning "No backend services found"
+    
+    # Delete backend configmaps and secrets
+    log_info "Cleaning up backend configs..."
+    kubectl delete configmap -l app.kubernetes.io/component=backend -n "$NAMESPACE" --ignore-not-found=true || log_warning "No backend configmaps found"
+    kubectl delete secret -l app.kubernetes.io/component=backend -n "$NAMESPACE" --ignore-not-found=true || log_warning "No backend secrets found"
+    
+    # Wait for pods to terminate
+    log_info "Waiting for backend pods to terminate..."
+    while kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/component=backend 2>/dev/null | grep -q "backend"; do
+        log_info "Waiting for backend pods to terminate..."
+        sleep 2
+    done
+    
+    # Docker cleanup - only backend images
+    log_info "Cleaning up backend Docker images..."
+    docker rmi "${IMAGE_NAME}:${IMAGE_TAG}" 2>/dev/null || log_warning "Image ${IMAGE_NAME}:${IMAGE_TAG} not found"
+    docker rmi "$(docker images -q ${IMAGE_NAME} 2>/dev/null)" 2>/dev/null || log_warning "No ${IMAGE_NAME} images found"
+    
+    # Remove backend image from minikube
+    log_info "Removing backend image from minikube..."
+    minikube image rm "${IMAGE_NAME}:${IMAGE_TAG}" 2>/dev/null || log_warning "Image not found in minikube"
+    
+    log_success "Targeted backend cleanup completed"
+}
+
+# Build Docker image with verification
+build_image() {
+    log_section "Building Docker Image"
+    
+    cd "$PROJECT_ROOT"
+    
+    # Verify source files
+    log_info "Verifying source files..."
+    if [[ ! -f "$BUILD_CONTEXT/services/kubernetesDiscovery.js" ]]; then
+        log_error "kubernetesDiscovery.js not found in $BUILD_CONTEXT/services/"
+        exit 1
+    fi
+    
+    # Show current API calls in source for verification
+    log_info "Current API calls in source:"
+    grep -n "await this.k8sApi" "$BUILD_CONTEXT/services/kubernetesDiscovery.js" || log_warning "No API calls found"
+    
+    # Build with no cache and verbose output
+    log_info "Building Docker image: ${IMAGE_NAME}:${IMAGE_TAG}"
+    docker build \
+        --no-cache \
+        --progress=plain \
+        --tag "${IMAGE_NAME}:${IMAGE_TAG}" \
+        "$BUILD_CONTEXT"
+    
+    # Verify build
+    if docker images | grep -q "${IMAGE_NAME}.*${IMAGE_TAG}"; then
+        log_success "Docker image built successfully"
+    else
+        log_error "Docker image build failed"
+        exit 1
+    fi
+    
+    # Load image into minikube
+    log_info "Loading image into minikube..."
+    minikube image load "${IMAGE_NAME}:${IMAGE_TAG}"
+    
+    # Verify image in minikube
+    if minikube image ls | grep -q "${IMAGE_NAME}:${IMAGE_TAG}"; then
+        log_success "Image loaded into minikube successfully"
+    else
+        log_error "Failed to load image into minikube"
+        exit 1
+    fi
+}
+
+# Deploy to Kubernetes
+deploy_to_k8s() {
+    log_section "Deploying to Kubernetes"
+    
+    cd "$PROJECT_ROOT"
+    
+    # Create namespace
+    log_info "Creating namespace: $NAMESPACE"
+    kubectl create namespace "$NAMESPACE" || log_warning "Namespace may already exist"
+    
+    # Pre-deployment validation
+    log_info "Validating deployment prerequisites..."
+    
+    # Check for any remaining conflicting resources
+    if kubectl get pv | grep -q "win98-disk-pv"; then
+        log_warning "Found existing persistent volume win98-disk-pv, attempting cleanup..."
+        kubectl delete pv win98-disk-pv --ignore-not-found=true || log_warning "Could not delete existing PV"
+        sleep 2
+    fi
+    
+    # Deploy with Helm - using simple image string format that matches chart structure
+    log_info "Deploying with Helm..."
+    
+    # Create a temporary values file that matches the chart's structure
+    cat > /tmp/helm-values.yaml << EOF
+# Set empty imageRepo to use full image paths
+imageRepo: ""
+
+backend:
+  image: ${IMAGE_NAME}
+  tag: ${IMAGE_TAG}
+  env:
+    ALLOW_EMPTY_DISCOVERY: "false"
+    FORCE_CONSOLE_LOGGING: "true" 
+    LOG_LEVEL: "debug"
+    KUBERNETES_NAMESPACE: "${NAMESPACE}"
+
+# Use full image paths for other components to override imageRepo
+frontend:
+  image: ghcr.io/mroie/loco-frontend
+  tag: latest
+
+vr:
+  image: ghcr.io/mroie/loco-frontend
+  tag: latest
+
+emulator:
+  image: ghcr.io/mroie/lego-loco-cluster/win98-softgpu
+  tag: latest
+
+nfs:
+  image: itsthenetwork/nfs-server-alpine:latest
+EOF
+    
+    # Deploy with the values file
+    if helm install "$HELM_RELEASE" "$HELM_CHART" \
+        --namespace "$NAMESPACE" \
+        --values /tmp/helm-values.yaml \
+        --wait \
+        --timeout=5m; then
+        log_success "Helm deployment completed successfully"
+    else
+        log_error "Helm deployment failed"
+        
+        # Show debug information
+        log_info "Helm status for debugging:"
+        helm status "$HELM_RELEASE" -n "$NAMESPACE" || true
+        
+        log_info "Kubernetes events for debugging:"
+        kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' | tail -10
+        
+        # Cleanup the failed deployment
+        helm uninstall "$HELM_RELEASE" -n "$NAMESPACE" 2>/dev/null || true
+        rm -f /tmp/helm-values.yaml
+        exit 1
+    fi
+    
+    # Cleanup temporary file
+    rm -f /tmp/helm-values.yaml
+    
+    log_success "Deployment completed"
+}
+
+# Verify deployment
+verify_deployment() {
+    log_section "Verifying Deployment"
+    
+    # Wait for pods to be ready
+    log_info "Waiting for pods to be ready..."
+    kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=loco -n "$NAMESPACE" --timeout=300s
+    
+    # Show pod status
+    log_info "Pod status:"
+    kubectl get pods -n "$NAMESPACE" -o wide
+    
+    # Show backend logs
+    log_info "Backend logs (last 20 lines):"
+    BACKEND_POD=$(kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/component=backend -o jsonpath='{.items[0].metadata.name}')
+    kubectl logs "$BACKEND_POD" -n "$NAMESPACE" --tail=20
+    
+    # Check for specific error
+    log_info "Checking for API parameter error..."
+    if kubectl logs "$BACKEND_POD" -n "$NAMESPACE" | grep -q "Required parameter namespace was null or undefined"; then
+        log_error "❌ API parameter error still present!"
+        return 1
+    else
+        log_success "✅ No API parameter error found"
+    fi
+    
+    # Test API connectivity
+    log_info "Testing API connectivity..."
+    kubectl port-forward -n "$NAMESPACE" "service/loco-backend" 3001:3001 &
+    PORT_FORWARD_PID=$!
+    sleep 5
+    
+    # Test health endpoint
+    if curl -f http://localhost:3001/health &> /dev/null; then
+        log_success "✅ Health endpoint accessible"
+    else
+        log_warning "⚠️ Health endpoint not accessible"
+    fi
+    
+    # Test instances endpoint
+    if curl -f http://localhost:3001/api/instances &> /dev/null; then
+        log_success "✅ Instances endpoint accessible"
+        # Show instance discovery results
+        log_info "Instance discovery results:"
+        curl -s http://localhost:3001/api/instances | head -20
+    else
+        log_warning "⚠️ Instances endpoint not accessible"
+    fi
+    
+    # Cleanup port forward
+    kill $PORT_FORWARD_PID 2>/dev/null || true
+}
+
+# Show debugging information
+show_debug_info() {
+    log_section "Debug Information"
+    
+    # Show image information
+    log_info "Docker images:"
+    docker images | grep -E "(${IMAGE_NAME}|REPOSITORY)" || log_warning "No matching images"
+    
+    # Show minikube images
+    log_info "Minikube images:"
+    minikube image ls | grep -E "(${IMAGE_NAME}|IMAGE)" || log_warning "No matching images in minikube"
+    
+    # Show Helm status
+    log_info "Helm status:"
+    helm status "$HELM_RELEASE" -n "$NAMESPACE" || log_warning "Helm release not found"
+    
+    # Show file verification in running container
+    if kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/component=backend &> /dev/null; then
+        BACKEND_POD=$(kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/component=backend -o jsonpath='{.items[0].metadata.name}')
+        log_info "Verifying file in running container:"
+        kubectl exec "$BACKEND_POD" -n "$NAMESPACE" -- grep -n "await this.k8sApi" /app/services/kubernetesDiscovery.js || log_warning "File verification failed"
+    fi
+}
+
+# Main execution
+main() {
+    log_section "Development Cycle Deploy Script"
+    log_info "Target: ${IMAGE_NAME}:${IMAGE_TAG} in namespace ${NAMESPACE}"
+    log_info "Project root: $PROJECT_ROOT"
+    
+    # Parse command line arguments
+    SKIP_CLEANUP=false
+    VERIFY_ONLY=false
+    DEBUG_ONLY=false
+    CLEANUP_ONLY=false
+    BACKEND_ONLY=false
+    
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --skip-cleanup)
+                SKIP_CLEANUP=true
+                shift
+                ;;
+            --verify-only)
+                VERIFY_ONLY=true
+                shift
+                ;;
+            --debug-only)
+                DEBUG_ONLY=true
+                shift
+                ;;
+            --cleanup-only)
+                CLEANUP_ONLY=true
+                shift
+                ;;
+            --backend-only)
+                BACKEND_ONLY=true
+                shift
+                ;;
+            --help)
+                echo "Usage: $0 [--skip-cleanup] [--verify-only] [--debug-only] [--cleanup-only] [--backend-only]"
+                echo "  --skip-cleanup   Skip the comprehensive cleanup step"
+                echo "  --verify-only    Only run verification steps"
+                echo "  --debug-only     Only show debug information"
+                echo "  --cleanup-only   Only run comprehensive cleanup"
+                echo "  --backend-only   Use targeted backend cleanup (faster, keeps emulators)"
+                exit 0
+                ;;
+            *)
+                log_error "Unknown parameter: $1"
+                exit 1
+                ;;
+        esac
+    done
+    
+    # Execute based on mode
+    if [[ "$DEBUG_ONLY" == "true" ]]; then
+        check_prerequisites
+        show_debug_info
+        exit 0
+    fi
+    
+    if [[ "$VERIFY_ONLY" == "true" ]]; then
+        check_prerequisites
+        verify_deployment
+        show_debug_info
+        exit 0
+    fi
+    
+    if [[ "$CLEANUP_ONLY" == "true" ]]; then
+        check_prerequisites
+        cleanup_all
+        log_success "🧹 Cleanup completed successfully!"
+        exit 0
+    fi
+    
+    # Full cycle
+    check_prerequisites
+    
+    if [[ "$SKIP_CLEANUP" != "true" ]]; then
+        if [[ "$BACKEND_ONLY" == "true" ]]; then
+            cleanup_backend_only
+        else
+            cleanup_all
+        fi
+    fi
+    
+    build_image
+    deploy_to_k8s
+    verify_deployment
+    show_debug_info
+    
+    log_section "Development Cycle Complete"
+    log_success "🎯 Development cycle completed successfully!"
+    log_info "🔍 Check the debug information above for any issues"
+    log_info "📝 Update RCA_KUBERNETES_DISCOVERY.md with results"
+    log_info "📝 Update RCA_KUBERNETES_DISCOVERY.md with results"
+}
+
+# Run main function with all arguments
+main "$@"

--- a/scripts/dev-cycle-deploy.sh
+++ b/scripts/dev-cycle-deploy.sh
@@ -8,7 +8,7 @@ set -e  # Exit on any error
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 IMAGE_NAME="loco-backend"
-IMAGE_TAG="latest"
+IMAGE_TAG="${IMAGE_TAG:-dev-$(date +%Y%m%d-%H%M%S)}"
 NAMESPACE="loco"
 HELM_RELEASE="loco"
 HELM_CHART="./helm/loco-chart"
@@ -122,10 +122,11 @@ cleanup_all() {
     
     # Additional cleanup for stuck resources
     log_info "Force cleaning any stuck resources..."
-    kubectl get all --all-namespaces | grep -E "(loco|emulator)" | awk '{print $1 "/" $2}' | while read resource; do
-        if [[ -n "$resource" && "$resource" != "/" ]]; then
-            log_info "Force deleting stuck resource: $resource"
-            kubectl delete "$resource" --force --grace-period=0 2>/dev/null || log_warning "Failed to force delete $resource"
+    # Column 1 is the namespace, column 2 the type/name pair - delete as "-n <ns> <type/name>"
+    kubectl get all --all-namespaces --no-headers 2>/dev/null | grep -E "(loco|emulator)" | awk '{print $1 " " $2}' | while read -r ns resource; do
+        if [[ -n "$ns" && -n "$resource" ]]; then
+            log_info "Force deleting stuck resource: $ns/$resource"
+            kubectl delete -n "$ns" "$resource" --force --grace-period=0 2>/dev/null || log_warning "Failed to force delete $ns/$resource"
         fi
     done
     
@@ -313,7 +314,7 @@ nfs:
 EOF
     
     # Deploy with the values file
-    if helm install "$HELM_RELEASE" "$HELM_CHART" \
+    if helm upgrade --install "$HELM_RELEASE" "$HELM_CHART" \
         --namespace "$NAMESPACE" \
         --values /tmp/helm-values.yaml \
         --wait \
@@ -509,8 +510,7 @@ main() {
     log_section "Development Cycle Complete"
     log_success "🎯 Development cycle completed successfully!"
     log_info "🔍 Check the debug information above for any issues"
-    log_info "📝 Update RCA_KUBERNETES_DISCOVERY.md with results"
-    log_info "📝 Update RCA_KUBERNETES_DISCOVERY.md with results"
+    log_info "📝 Update docs/RCA_KUBERNETES_DISCOVERY.md with results"
 }
 
 # Run main function with all arguments

--- a/scripts/simple-backend-deploy.sh
+++ b/scripts/simple-backend-deploy.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+# Simple backend-only deployment script to isolate and fix the API issue
+
+set -e
+
+# Configuration
+IMAGE_NAME="loco-backend"
+IMAGE_TAG="latest"
+NAMESPACE="loco"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_section() {
+    echo -e "\n${BLUE}==== $1 ====${NC}"
+}
+
+# Build and deploy backend only
+deploy_backend_simple() {
+    log_section "Simple Backend Deployment"
+    
+    # Build image
+    log_info "Building backend image..."
+    cd backend
+    docker build --no-cache -t "${IMAGE_NAME}:${IMAGE_TAG}" .
+    cd ..
+    
+    # Load into minikube
+    log_info "Loading image into minikube..."
+    minikube image load "${IMAGE_NAME}:${IMAGE_TAG}"
+    
+    # Create namespace
+    log_info "Creating namespace..."
+    kubectl create namespace "$NAMESPACE" || echo "Namespace exists"
+    
+    # Create simple backend deployment
+    log_info "Creating backend deployment..."
+    cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loco-backend
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loco-backend
+  template:
+    metadata:
+      labels:
+        app: loco-backend
+        app.kubernetes.io/component: backend
+    spec:
+      serviceAccountName: loco-backend-sa
+      containers:
+      - name: backend
+        image: ${IMAGE_NAME}:${IMAGE_TAG}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 3001
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: ALLOW_EMPTY_DISCOVERY
+          value: "false"
+        - name: FORCE_CONSOLE_LOGGING
+          value: "true"
+        - name: LOG_LEVEL
+          value: "debug"
+        - name: KUBERNETES_NAMESPACE
+          value: "${NAMESPACE}"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loco-backend
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: loco-backend
+  ports:
+  - port: 3001
+    targetPort: 3001
+  type: ClusterIP
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loco-backend-sa
+  namespace: ${NAMESPACE}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: loco-backend-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services", "namespaces"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["statefulsets"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: loco-backend-cluster-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: loco-backend-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: loco-backend-sa
+  namespace: ${NAMESPACE}
+EOF
+    
+    # Wait for deployment
+    log_info "Waiting for backend to be ready..."
+    kubectl wait --for=condition=available deployment/loco-backend -n "$NAMESPACE" --timeout=300s
+    
+    log_success "Backend deployed successfully!"
+}
+
+# Test and debug
+test_backend() {
+    log_section "Testing Backend"
+    
+    # Show pod status
+    log_info "Pod status:"
+    kubectl get pods -n "$NAMESPACE" -l app=loco-backend
+    
+    # Show logs
+    log_info "Backend logs:"
+    BACKEND_POD=$(kubectl get pods -n "$NAMESPACE" -l app=loco-backend -o jsonpath='{.items[0].metadata.name}')
+    kubectl logs "$BACKEND_POD" -n "$NAMESPACE" --tail=30
+    
+    # Check for API error
+    log_info "Checking for API parameter error..."
+    if kubectl logs "$BACKEND_POD" -n "$NAMESPACE" | grep -q "Required parameter namespace was null or undefined"; then
+        log_error "❌ API parameter error still present!"
+        
+        # Show file in container to verify it matches source
+        log_info "Checking file in running container:"
+        kubectl exec "$BACKEND_POD" -n "$NAMESPACE" -- grep -n "await this.k8sApi" /app/services/kubernetesDiscovery.js
+        
+        return 1
+    else
+        log_success "✅ No API parameter error found!"
+        return 0
+    fi
+}
+
+# Port forward for testing
+test_api() {
+    log_section "Testing API"
+    
+    log_info "Port forwarding backend service..."
+    kubectl port-forward -n "$NAMESPACE" service/loco-backend 3001:3001 &
+    PORT_FORWARD_PID=$!
+    sleep 5
+    
+    # Test endpoints
+    log_info "Testing health endpoint..."
+    if curl -f http://localhost:3001/health 2>/dev/null; then
+        log_success "✅ Health endpoint working"
+    else
+        log_error "❌ Health endpoint failed"
+    fi
+    
+    log_info "Testing instances endpoint..."
+    curl -s http://localhost:3001/api/instances | head -10
+    
+    # Cleanup
+    kill $PORT_FORWARD_PID 2>/dev/null || true
+}
+
+# Main execution
+main() {
+    log_section "Simple Backend Deployment Script"
+    
+    deploy_backend_simple
+    test_backend
+    
+    if [ $? -eq 0 ]; then
+        test_api
+        log_success "🎯 Backend deployment and testing completed successfully!"
+    else
+        log_error "❌ Backend still has API issues - need further investigation"
+        exit 1
+    fi
+}
+
+main "$@"

--- a/scripts/simple-backend-deploy.sh
+++ b/scripts/simple-backend-deploy.sh
@@ -5,7 +5,7 @@ set -e
 
 # Configuration
 IMAGE_NAME="loco-backend"
-IMAGE_TAG="latest"
+IMAGE_TAG="${IMAGE_TAG:-dev-$(date +%Y%m%d-%H%M%S)}"
 NAMESPACE="loco"
 
 # Colors for output
@@ -72,7 +72,7 @@ spec:
       containers:
       - name: backend
         image: ${IMAGE_NAME}:${IMAGE_TAG}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3001
         env:


### PR DESCRIPTION
## Summary
Replaces PR #91 (`integrations`), which had drifted 20+ commits behind main with conflicts in files main has since rewritten. Per CONSOLIDATION_PLAN.md Phase 4, this brings over only what is still valuable:

- **Structured logging**: converts the remaining 21 `console.*` calls in `kubernetesDiscovery.js` and `instanceManager.js` to the winston logger that landed via #89 — keeping main's newer discovery/namespace logic that #91's copies predated.
- **`scripts/dev-cycle-deploy.sh`**: full build→kind-load→helm-deploy→verify development cycle.
- **`scripts/simple-backend-deploy.sh`**: quick backend-only redeploy.
- **`docs/RCA_KUBERNETES_DISCOVERY.md`**: root-cause analysis of the k8s discovery failure (already fixed on main).

Deliberately not taken: #91's logger implementation (different API; main's is already wired), its stale `server.js`/helm diffs, and its stale `kubernetesDiscovery.js`.

## Testing
Backend jest suite: 42 passed / 17 failed — identical to main's baseline (failing suites are pre-existing infra-dependent tests that also fail on main). Both deploy scripts pass `bash -n`.

Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)