### PR TITLE
chore(build): trim docker build contexts (adopts #77's .dockerignore concept)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,17 @@
-node_modules
-.git
-.DS_Store
-*.log
+# Root build context is only used by backend/Dockerfile, which copies
+# backend/, utils/ and (at runtime) config/. Allowlist those and exclude
+# everything else — the working tree carries multi-GB ISOs, disk images
+# and bake artifacts that otherwise ship to the daemon on every build.
+*
+
+!backend
+!utils
+!config
+
+# Re-exclude junk inside the allowed trees
+backend/node_modules
+backend/logs
+backend/coverage
+backend/*.log
+**/.DS_Store
+**/npm-debug.log*

--- a/containers/qemu-softgpu/.dockerignore
+++ b/containers/qemu-softgpu/.dockerignore
@@ -1,0 +1,9 @@
+# Keep the emulator build context lean — bake artifacts and stray disk
+# images in this directory can exceed 1 GB and are never COPY'd.
+tmp-bake
+*.qcow2
+*.iso
+*.tar
+*.tar.gz
+*.md
+.DS_Store

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+coverage
+*.log
+.DS_Store


### PR DESCRIPTION
First of four salvage items from the open draft PRs (per the adoption assessment): #77's build-context hygiene, re-implemented for today's tree.

- Root `.dockerignore` becomes an allowlist (backend builds only need `backend/`, `utils/`, `config/`) — context transfer drops from multi-GB (ISOs, qcow2s, bake artifacts in the working tree) to **~223 kB**, verified with a real `docker build --target production`.
- `containers/qemu-softgpu/.dockerignore` excludes the 1.2 GB `tmp-bake/` directory and stray disk images.
- `frontend/.dockerignore` excludes node_modules/dist.

The other half of #77's concept (emulator memory limits) is already on main via the consolidation (2Gi limit / 1Gi request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)