### PR TITLE
feat(backend): circuit breakers for k8s API calls (adopts #79's concept)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "@kubernetes/client-node": "^1.3.0",
     "express": "^4.18.2",
     "http-proxy": "^1.18.1",
+    "opossum": "^8.1.4",
     "prom-client": "^15.1.0",
     "rfb2": "^0.2.2",
     "winston": "^3.17.0",

--- a/backend/server.js
+++ b/backend/server.js
@@ -654,6 +654,35 @@ app.get("/api/quality/summary", (req, res) => {
 });
 
 // ==========================================
+// Circuit Breaker Observability API
+// ==========================================
+
+/**
+ * Get state and metrics for every circuit breaker protecting external calls.
+ * @route GET /api/circuit-breakers
+ */
+app.get("/api/circuit-breakers", (req, res) => {
+  const breakerManager = require("./services/circuitBreaker");
+  res.json({
+    summary: breakerManager.getSummary(),
+    breakers: breakerManager.getAllMetrics(),
+  });
+});
+
+/**
+ * Get metrics for one circuit breaker by name.
+ * @route GET /api/circuit-breakers/:name
+ */
+app.get("/api/circuit-breakers/:name", (req, res) => {
+  const breakerManager = require("./services/circuitBreaker");
+  const metrics = breakerManager.getMetrics(req.params.name);
+  if (!metrics) {
+    return res.status(404).json({ error: `Unknown circuit breaker: ${req.params.name}` });
+  }
+  res.json(metrics);
+});
+
+// ==========================================
 // LAN Topology Dashboard API
 // ==========================================
 

--- a/backend/services/circuitBreaker.js
+++ b/backend/services/circuitBreaker.js
@@ -1,0 +1,205 @@
+const CircuitBreaker = require('opossum');
+const logger = require('../utils/logger');
+
+/**
+ * Circuit breaker manager for external dependencies (concept from PR #79).
+ *
+ * Wraps functions with opossum circuit breakers, collects per-breaker
+ * metrics, and provides cached-data fallbacks so the backend keeps serving
+ * last-known-good data when an external service (the Kubernetes API) is
+ * unavailable instead of cascading the failure.
+ */
+class CircuitBreakerManager {
+  constructor() {
+    this.breakers = new Map();
+    this.metrics = new Map();
+
+    this.defaultOptions = {
+      timeout: 10000, // 10s — k8s API calls can be slow on loaded clusters
+      errorThresholdPercentage: 60, // trip at 60% error rate
+      resetTimeout: 30000, // 30s before attempting half-open
+      rollingCountTimeout: 60000, // 1 minute rolling window
+      rollingCountBuckets: 10,
+    };
+  }
+
+  /**
+   * Create (or return an existing) circuit breaker for a function.
+   * @param {string} name - unique breaker name
+   * @param {Function} fn - async function to protect
+   * @param {Object} [options] - opossum option overrides (+ optional fallback)
+   * @returns {CircuitBreaker}
+   */
+  createBreaker(name, fn, options = {}) {
+    if (this.breakers.has(name)) {
+      return this.breakers.get(name);
+    }
+
+    const { fallback, ...opossumOptions } = options;
+    const breaker = new CircuitBreaker(fn, {
+      ...this.defaultOptions,
+      ...opossumOptions,
+      name,
+    });
+
+    if (typeof fallback === 'function') {
+      breaker.fallback(fallback);
+    }
+
+    this.setupEventListeners(breaker, name);
+    this.breakers.set(name, breaker);
+    logger.info('Circuit breaker created', { breaker: name });
+    return breaker;
+  }
+
+  setupEventListeners(breaker, name) {
+    this.metrics.set(name, {
+      state: 'CLOSED',
+      failures: 0,
+      successes: 0,
+      timeouts: 0,
+      opens: 0,
+      halfOpens: 0,
+      closes: 0,
+      fallbacks: 0,
+      lastStateChange: new Date().toISOString(),
+      stats: {
+        totalRequests: 0,
+        totalFailures: 0,
+        totalSuccesses: 0,
+        errorRate: 0,
+      },
+    });
+
+    const metrics = this.metrics.get(name);
+
+    breaker.on('open', () => {
+      metrics.state = 'OPEN';
+      metrics.opens++;
+      metrics.lastStateChange = new Date().toISOString();
+      logger.warn('Circuit breaker opened', { breaker: name });
+    });
+
+    breaker.on('halfOpen', () => {
+      metrics.state = 'HALF_OPEN';
+      metrics.halfOpens++;
+      metrics.lastStateChange = new Date().toISOString();
+      logger.info('Circuit breaker half-open', { breaker: name });
+    });
+
+    breaker.on('close', () => {
+      metrics.state = 'CLOSED';
+      metrics.closes++;
+      metrics.lastStateChange = new Date().toISOString();
+      logger.info('Circuit breaker closed', { breaker: name });
+    });
+
+    breaker.on('success', () => {
+      metrics.successes++;
+      metrics.stats.totalSuccesses++;
+      metrics.stats.totalRequests++;
+      this.updateStats(metrics);
+    });
+
+    breaker.on('failure', (error) => {
+      metrics.failures++;
+      metrics.stats.totalFailures++;
+      metrics.stats.totalRequests++;
+      this.updateStats(metrics);
+      logger.warn('Circuit breaker failure', { breaker: name, error: error?.message });
+    });
+
+    breaker.on('timeout', () => {
+      metrics.timeouts++;
+      metrics.stats.totalFailures++;
+      metrics.stats.totalRequests++;
+      this.updateStats(metrics);
+      logger.warn('Circuit breaker timeout', { breaker: name });
+    });
+
+    breaker.on('fallback', () => {
+      metrics.fallbacks++;
+      logger.info('Circuit breaker fallback served', { breaker: name });
+    });
+  }
+
+  updateStats(metrics) {
+    const { totalRequests, totalFailures } = metrics.stats;
+    metrics.stats.errorRate = totalRequests > 0 ? (totalFailures / totalRequests) * 100 : 0;
+  }
+
+  getBreaker(name) {
+    return this.breakers.get(name) || null;
+  }
+
+  getMetrics(name) {
+    return this.metrics.get(name) || null;
+  }
+
+  getAllMetrics() {
+    const allMetrics = {};
+    for (const [name, metrics] of this.metrics) {
+      const breaker = this.breakers.get(name);
+      allMetrics[name] = {
+        ...metrics,
+        currentState: breaker?.opened ? 'OPEN' : breaker?.halfOpen ? 'HALF_OPEN' : 'CLOSED',
+      };
+    }
+    return allMetrics;
+  }
+
+  getSummary() {
+    const summary = {
+      totalBreakers: this.breakers.size,
+      openBreakers: 0,
+      halfOpenBreakers: 0,
+      closedBreakers: 0,
+      totalRequests: 0,
+      totalFailures: 0,
+      overallErrorRate: 0,
+    };
+
+    for (const [name, metrics] of this.metrics) {
+      const breaker = this.breakers.get(name);
+      if (breaker?.opened) summary.openBreakers++;
+      else if (breaker?.halfOpen) summary.halfOpenBreakers++;
+      else summary.closedBreakers++;
+
+      summary.totalRequests += metrics.stats.totalRequests;
+      summary.totalFailures += metrics.stats.totalFailures;
+    }
+
+    summary.overallErrorRate =
+      summary.totalRequests > 0 ? (summary.totalFailures / summary.totalRequests) * 100 : 0;
+
+    return summary;
+  }
+
+  /**
+   * Build a fallback that serves data from a getter at open-circuit time
+   * (a getter, not a snapshot — the cache may be refreshed between trips).
+   */
+  createCacheFallback(getCachedData, description = 'cached data') {
+    return () => {
+      logger.info('Serving circuit breaker fallback', { source: description });
+      return getCachedData();
+    };
+  }
+
+  shutdown() {
+    for (const [name, breaker] of this.breakers) {
+      try {
+        breaker.shutdown();
+        logger.info('Circuit breaker shut down', { breaker: name });
+      } catch (error) {
+        logger.warn('Failed to shut down circuit breaker', { breaker: name, error: error.message });
+      }
+    }
+    this.breakers.clear();
+    this.metrics.clear();
+  }
+}
+
+// Singleton shared across the backend
+module.exports = new CircuitBreakerManager();
+module.exports.CircuitBreakerManager = CircuitBreakerManager;

--- a/backend/services/kubernetesDiscovery.js
+++ b/backend/services/kubernetesDiscovery.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const logger = require('../utils/logger');
+const breakerManager = require('./circuitBreaker');
 
 class KubernetesDiscovery {
   constructor() {
@@ -16,6 +17,11 @@ class KubernetesDiscovery {
     this.discoveryStrategy = process.env.DISCOVERY_STRATEGY || 'auto';
     this.serviceName = process.env.EMULATOR_SERVICE_NAME || 'loco-loco-emulator';
     this.endpointsWatchRequest = null;
+
+    // Last-known-good API responses, served as circuit-breaker fallbacks so
+    // the dashboard keeps rendering while the Kubernetes API is unavailable
+    this.lastGood = { podsAndStatefulSets: null, services: null };
+    this.breakers = null; // created lazily once the k8s client is initialized
 
     // Initialize asynchronously
     this.init().catch(error => {
@@ -145,12 +151,29 @@ class KubernetesDiscovery {
 
       logger.info(`API call parameters:`, { pods: listPodsParams, statefulSets: listStatefulSetsParams });
 
-      // Execute both API calls in parallel for efficiency
-      // The newer Kubernetes client expects an object with namespace and other options
-      const [podsResponse, statefulSetsResponse] = await Promise.all([
-        this.k8sApi.listNamespacedPod({ namespace, labelSelector }),
-        this.k8sAppsApi.listNamespacedStatefulSet({ namespace, labelSelector })
-      ]);
+      // Execute both API calls in parallel for efficiency, behind a circuit
+      // breaker: when the k8s API is failing, serve the last-known-good
+      // response instead of cascading errors to the dashboard.
+      const listBreaker = breakerManager.createBreaker(
+        'k8s-list-pods-statefulsets',
+        (ns, sel) => Promise.all([
+          this.k8sApi.listNamespacedPod({ namespace: ns, labelSelector: sel }),
+          this.k8sAppsApi.listNamespacedStatefulSet({ namespace: ns, labelSelector: sel })
+        ]),
+        {
+          fallback: breakerManager.createCacheFallback(
+            () => this.lastGood.podsAndStatefulSets,
+            'last-known pods/statefulsets'
+          ),
+        }
+      );
+      const listResult = await listBreaker.fire(namespace, labelSelector);
+      if (!listResult) {
+        logger.warn('Kubernetes API unavailable and no cached pods/statefulsets yet');
+        return [];
+      }
+      const [podsResponse, statefulSetsResponse] = listResult;
+      this.lastGood.podsAndStatefulSets = listResult;
 
       // Handle both old (response.body) and new (response directly) client-node formats
       const podsBody = podsResponse?.body || podsResponse;
@@ -302,7 +325,20 @@ class KubernetesDiscovery {
         labelSelector: labelSelector
       };
 
-      const servicesResponse = await this.k8sApi.listNamespacedService(listServicesParams);
+      const servicesBreaker = breakerManager.createBreaker(
+        'k8s-list-services',
+        (params) => this.k8sApi.listNamespacedService(params),
+        {
+          fallback: breakerManager.createCacheFallback(
+            () => this.lastGood.services,
+            'last-known services'
+          ),
+        }
+      );
+      const servicesResponse = await servicesBreaker.fire(listServicesParams);
+      if (servicesResponse) {
+        this.lastGood.services = servicesResponse;
+      }
 
       // Handle both old (response.body) and new (response directly) client-node formats
       const body = servicesResponse?.body || servicesResponse;

--- a/backend/tests/circuitBreaker.test.js
+++ b/backend/tests/circuitBreaker.test.js
@@ -1,0 +1,193 @@
+const circuitBreakerManager = require('../services/circuitBreaker');
+
+describe('Circuit Breaker Manager', () => {
+  beforeEach(() => {
+    circuitBreakerManager.shutdown();
+  });
+
+  afterAll(() => {
+    circuitBreakerManager.shutdown();
+  });
+
+  test('should create a circuit breaker with default options', () => {
+    const mockFn = jest.fn().mockResolvedValue('success');
+    const breaker = circuitBreakerManager.createBreaker('test-breaker', mockFn);
+
+    expect(breaker).toBeDefined();
+    expect(breaker.name).toBe('test-breaker');
+    expect(breaker.closed).toBe(true);
+  });
+
+  test('should return existing breaker if already created', () => {
+    const mockFn = jest.fn().mockResolvedValue('success');
+    const breaker1 = circuitBreakerManager.createBreaker('test-breaker', mockFn);
+    const breaker2 = circuitBreakerManager.createBreaker('test-breaker', mockFn);
+
+    expect(breaker1).toBe(breaker2);
+  });
+
+  test('should execute function through circuit breaker successfully', async () => {
+    const mockFn = jest.fn().mockResolvedValue('success');
+    const breaker = circuitBreakerManager.createBreaker('test-success', mockFn);
+
+    const result = await breaker.fire('test-arg');
+
+    expect(result).toBe('success');
+    expect(mockFn).toHaveBeenCalledWith('test-arg');
+  });
+
+  test('should collect metrics for successful calls', async () => {
+    const mockFn = jest.fn().mockResolvedValue('success');
+    const breaker = circuitBreakerManager.createBreaker('test-metrics', mockFn);
+
+    await breaker.fire();
+
+    const metrics = circuitBreakerManager.getMetrics('test-metrics');
+    expect(metrics).toBeDefined();
+    expect(metrics.successes).toBe(1);
+    expect(metrics.stats.totalSuccesses).toBe(1);
+    expect(metrics.stats.totalRequests).toBe(1);
+    expect(metrics.state).toBe('CLOSED');
+  });
+
+  test('should collect metrics for failed calls', async () => {
+    const mockFn = jest.fn().mockRejectedValue(new Error('test error'));
+    const breaker = circuitBreakerManager.createBreaker('test-failures', mockFn);
+
+    await expect(breaker.fire()).rejects.toThrow('test error');
+
+    const metrics = circuitBreakerManager.getMetrics('test-failures');
+    expect(metrics).toBeDefined();
+    expect(metrics.failures).toBe(1);
+    expect(metrics.stats.totalFailures).toBe(1);
+    expect(metrics.stats.totalRequests).toBe(1);
+    expect(metrics.stats.errorRate).toBe(100);
+  });
+
+  test('should open circuit breaker after threshold failures', async () => {
+    const mockFn = jest.fn().mockRejectedValue(new Error('test error'));
+    const breaker = circuitBreakerManager.createBreaker('test-open', mockFn, {
+      errorThresholdPercentage: 50,
+      rollingCountBuckets: 2,
+      rollingCountTimeout: 1000,
+    });
+
+    for (let i = 0; i < 5; i++) {
+      try {
+        await breaker.fire();
+      } catch (error) {
+        // expected
+      }
+    }
+
+    const metrics = circuitBreakerManager.getMetrics('test-open');
+    expect(metrics.stats.errorRate).toBeGreaterThan(0);
+  });
+
+  test('should serve fallback once the circuit is open', async () => {
+    const mockFn = jest.fn().mockRejectedValue(new Error('test error'));
+    const fallbackData = { cached: true };
+
+    const breaker = circuitBreakerManager.createBreaker('test-fallback', mockFn, {
+      errorThresholdPercentage: 50,
+      rollingCountBuckets: 2,
+      rollingCountTimeout: 1000,
+      fallback: () => fallbackData,
+    });
+
+    // With a fallback configured, opossum resolves with the fallback value
+    // on failure instead of rejecting.
+    let lastResult;
+    for (let i = 0; i < 5; i++) {
+      lastResult = await breaker.fire();
+    }
+
+    expect(lastResult).toEqual(fallbackData);
+    const metrics = circuitBreakerManager.getMetrics('test-fallback');
+    expect(metrics.state).toBe('OPEN');
+    expect(metrics.failures).toBeGreaterThan(0);
+    expect(metrics.fallbacks).toBeGreaterThan(0);
+  });
+
+  test('should provide summary statistics', async () => {
+    const mockFn1 = jest.fn().mockResolvedValue('success');
+    const mockFn2 = jest.fn().mockRejectedValue(new Error('error'));
+
+    const breaker1 = circuitBreakerManager.createBreaker('summary-test-1', mockFn1);
+    const breaker2 = circuitBreakerManager.createBreaker('summary-test-2', mockFn2);
+
+    await breaker1.fire();
+    try {
+      await breaker2.fire();
+    } catch (error) {
+      // expected
+    }
+
+    const summary = circuitBreakerManager.getSummary();
+    expect(summary.totalBreakers).toBe(2);
+    expect(summary.totalRequests).toBe(2);
+    expect(summary.totalFailures).toBe(1);
+    expect(summary.overallErrorRate).toBe(50);
+  });
+
+  test('should return all metrics', async () => {
+    const mockFn = jest.fn().mockResolvedValue('success');
+    const breaker = circuitBreakerManager.createBreaker('all-metrics-test', mockFn);
+
+    await breaker.fire();
+
+    const allMetrics = circuitBreakerManager.getAllMetrics();
+    expect(allMetrics['all-metrics-test']).toBeDefined();
+    expect(allMetrics['all-metrics-test'].successes).toBe(1);
+    expect(allMetrics['all-metrics-test'].currentState).toBe('CLOSED');
+  });
+
+  test('should handle circuit breaker timeout', async () => {
+    const mockFn = jest.fn().mockImplementation(
+      () => new Promise((resolve) => setTimeout(resolve, 100))
+    );
+
+    const breaker = circuitBreakerManager.createBreaker('timeout-test', mockFn, {
+      timeout: 50,
+    });
+
+    try {
+      await breaker.fire();
+    } catch (error) {
+      // expected timeout
+    }
+
+    const metrics = circuitBreakerManager.getMetrics('timeout-test');
+    expect(metrics.timeouts).toBe(1);
+  });
+
+  test('should clean up resources on shutdown', () => {
+    const mockFn = jest.fn().mockResolvedValue('success');
+    circuitBreakerManager.createBreaker('shutdown-test', mockFn);
+
+    expect(circuitBreakerManager.getAllMetrics()['shutdown-test']).toBeDefined();
+
+    circuitBreakerManager.shutdown();
+
+    expect(Object.keys(circuitBreakerManager.getAllMetrics())).toHaveLength(0);
+  });
+});
+
+describe('Circuit Breaker Cache Fallback', () => {
+  test('should serve data from a getter so refreshed caches are picked up', () => {
+    let cache = { generation: 1 };
+    const fallback = circuitBreakerManager.createCacheFallback(() => cache, 'test data');
+
+    expect(typeof fallback).toBe('function');
+    expect(fallback()).toEqual({ generation: 1 });
+
+    cache = { generation: 2 };
+    expect(fallback()).toEqual({ generation: 2 });
+  });
+
+  test('should pass through different data types', () => {
+    expect(circuitBreakerManager.createCacheFallback(() => [1, 2, 3])()).toEqual([1, 2, 3]);
+    expect(circuitBreakerManager.createCacheFallback(() => 'test string')()).toBe('test string');
+    expect(circuitBreakerManager.createCacheFallback(() => null)()).toBeNull();
+  });
+});


### PR DESCRIPTION
Second salvage item from the draft-PR adoption assessment: #79's circuit breaker pattern, re-implemented on today's kubernetesDiscovery.

- `CircuitBreakerManager` (opossum): 10s timeout, 60% error threshold, 30s reset, per-breaker metrics through the winston logger.
- The two hot k8s API paths (pods+statefulsets list, services list) get breakers with **last-known-good fallbacks** — the dashboard keeps serving cached topology during API outages instead of cascading failures (this repo's discovery RCA is exactly this failure class).
- `GET /api/circuit-breakers` and `GET /api/circuit-breakers/:name` for observability.
- 13 unit tests (ported + adapted from #79). Full backend suite: 63 passed / 9 failed — the 9 are the same pre-existing infra-dependent failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)