### PR TITLE
feat(frontend): progressive loading + LEGO loading overlay (adopts #74's concepts)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,14 @@ server {
     
     root /usr/share/nginx/html;
     index index.html;
+
+    # Gzip compression (concept from #74)
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css application/json application/javascript
+               text/xml application/xml application/xml+rss image/svg+xml;
     
     # Proxy API calls to backend
     location /api/ {

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -4,6 +4,14 @@ server {
     
     root /usr/share/nginx/html;
     index index.html;
+
+    # Gzip compression (concept from #74)
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css application/json application/javascript
+               text/xml application/xml application/xml+rss image/svg+xml;
     
     # Proxy API calls to backend
     location /api/ {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "react-vnc": "^3.1.0"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.1.0",
     "@vitejs/plugin-react": "^4.5.2",
     "autoprefixer": "^10.0.0",
     "jsdom": "^27.2.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,7 +5,8 @@ import InstanceCard from "./components/InstanceCard";
 import DiscoveryStatus from "./components/DiscoveryStatus";
 import BenchmarkOverlay from "./components/BenchmarkOverlay";
 import FullscreenViewer from "./components/FullscreenViewer";
-import { fetchLiveInstances } from "./api/discovery";
+import useProgressiveLoading from "./hooks/useProgressiveLoading";
+import AppLoadingOverlay from "./components/AppLoadingOverlay";
 
 const VRScene = lazy(() => import(/* webpackChunkName: "vr" */ "./VRScene"));
 const QualityDashboard = lazy(() => import(/* webpackChunkName: "dashboard" */ "./components/QualityDashboard"));
@@ -14,16 +15,21 @@ const QualityDashboard = lazy(() => import(/* webpackChunkName: "dashboard" */ "
 // Main dashboard component showing the 3×3 grid of instances
 export default function App() {
   const { activeIds, setActiveIds } = useActive();
-  const [instances, setInstances] = useState([]);
-  const [provisionedInstances, setProvisionedInstances] = useState([]);
-  const [discoveryStatus, setDiscoveryStatus] = useState(null);
+  const {
+    instances,
+    provisionedInstances,
+    discoveryStatus,
+    hotkeys,
+    status,
+    loadingStates,
+    errors: loadingErrors,
+    isCriticalDataLoaded,
+  } = useProgressiveLoading();
   const [showBenchmark, setShowBenchmark] = useState(true);
-  const [hotkeys, setHotkeys] = useState({});
   const [active, setActive] = useState(0);
   const [zoom, setZoom] = useState(1);
   const defaultVr = import.meta.env.VITE_DEFAULT_VR === 'true';
   const [vrMode, setVrMode] = useState(defaultVr);
-  const [status, setStatus] = useState({});
   const [focused, setFocused] = useState(null);
   const [showOnlyProvisioned, setShowOnlyProvisioned] = useState(false);
   const [fullscreenInstance, setFullscreenInstance] = useState(null);
@@ -53,56 +59,6 @@ export default function App() {
     setActiveIds([id]);
   };
 
-  // Fetch instance list and hotkey mapping from the backend
-  useEffect(() => {
-    const loadInstances = () => {
-      // Load live instances with metadata
-      fetchLiveInstances()
-        .then((data) => {
-          setInstances(data.instances || []);
-          setDiscoveryStatus(data);
-
-          // Also update provisioned list (filter client-side or fetch separate if needed)
-          // For now, we'll assume provisioned are those with status='ready' or explicit flag
-          const provisioned = (data.instances || []).filter(i => i.provisioned || i.status === 'ready');
-          setProvisionedInstances(provisioned);
-        })
-        .catch((e) => console.error("Failed to fetch live instances", e));
-    };
-
-    // Initial load
-    loadInstances();
-
-    fetch("/api/config/hotkeys")
-      .then((r) => r.json())
-      .then(setHotkeys)
-      .catch((e) => console.error("Failed to fetch hotkeys", e));
-
-    const interval = setInterval(() => {
-      fetch("/api/status")
-        .then((r) => r.json())
-        .then(setStatus)
-        .catch(() => { });
-
-      // Refresh instances periodically
-      loadInstances();
-    }, 5000);
-
-    fetch("/api/status").then((r) => r.json()).then(setStatus).catch(() => { });
-
-    // Listen for discovery refresh events
-    const handleDiscoveryRefresh = () => {
-      console.log('Discovery refreshed, reloading instances');
-      loadInstances();
-    };
-
-    window.addEventListener('discoveryRefreshed', handleDiscoveryRefresh);
-
-    return () => {
-      clearInterval(interval);
-      window.removeEventListener('discoveryRefreshed', handleDiscoveryRefresh);
-    };
-  }, []);
 
   // Update active index when activeIds or instances change
   useEffect(() => {
@@ -191,6 +147,13 @@ export default function App() {
 
   return (
     <div className="min-h-screen lego-background text-black relative">
+      {/* Initial-load overlay (progressive loading, concept from #74) */}
+      <AppLoadingOverlay
+        isVisible={loadingStates.initialLoad}
+        loadingStates={loadingStates}
+        isCriticalDataLoaded={isCriticalDataLoaded}
+        errors={loadingErrors}
+      />
       {/* Live Benchmark Overlay */}
       <BenchmarkOverlay
         visible={showBenchmark && !vrMode}

--- a/frontend/src/components/AppLoadingOverlay.jsx
+++ b/frontend/src/components/AppLoadingOverlay.jsx
@@ -1,0 +1,207 @@
+import React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import LoadingSpinner from './LoadingSpinner';
+
+/**
+ * Full-screen loading overlay for initial app load
+ * Shows progressive loading stages with LEGO theming
+ */
+export default function AppLoadingOverlay({ 
+  isVisible,
+  loadingStates,
+  isCriticalDataLoaded,
+  errors 
+}) {
+  if (!isVisible) return null;
+
+  const getLoadingMessage = () => {
+    if (errors.instances || errors.provisionedInstances) {
+      return "Connection issues - retrying...";
+    }
+    
+    if (loadingStates.instances || loadingStates.provisionedInstances) {
+      return "Loading LEGO Loco instances...";
+    }
+    
+    if (loadingStates.hotkeys || loadingStates.status) {
+      return "Loading configuration...";
+    }
+    
+    return "Almost ready!";
+  };
+
+  const getProgressPercentage = () => {
+    const totalSteps = 4; // instances, provisionedInstances, hotkeys, status
+    const completedSteps = Object.entries(loadingStates)
+      .filter(([key, loading]) => key !== 'initialLoad' && !loading)
+      .length;
+    return Math.round((completedSteps / totalSteps) * 100);
+  };
+
+  const hasErrors = errors.instances || errors.provisionedInstances;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        className="fixed inset-0 bg-gradient-to-br from-green-600 via-green-500 to-blue-600 z-50 flex items-center justify-center"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.3 }}
+      >
+        {/* LEGO-style background pattern */}
+        <div className="absolute inset-0 opacity-10">
+          <div className="grid grid-cols-20 grid-rows-20 h-full w-full">
+            {Array(400).fill(0).map((_, i) => (
+              <motion.div 
+                key={i} 
+                className="border border-white/20"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ delay: i * 0.001 }}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Main loading content */}
+        <motion.div
+          className="relative z-10 text-center max-w-md mx-auto px-6"
+          initial={{ scale: 0.8, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ delay: 0.2, duration: 0.5 }}
+        >
+          {/* LEGO Loco Logo/Title */}
+          <motion.div
+            className="mb-8"
+            animate={{ y: [0, -5, 0] }}
+            transition={{ repeat: Infinity, duration: 3, ease: "easeInOut" }}
+          >
+            <h1 className="text-4xl font-bold text-white lego-text tracking-wider mb-2">
+              🚂 LEGO LOCO
+            </h1>
+            <h2 className="text-xl text-yellow-200 lego-text">
+              Cluster Dashboard
+            </h2>
+          </motion.div>
+
+          {/* Loading spinner */}
+          <div className="mb-6">
+            <LoadingSpinner 
+              size="lg" 
+              message={getLoadingMessage()}
+              variant="light"
+            />
+          </div>
+
+          {/* Progress bar */}
+          <div className="mb-6">
+            <div className="w-full h-4 bg-white/20 rounded-lg overflow-hidden shadow-inner">
+              <motion.div
+                className={`h-full rounded-lg ${
+                  hasErrors 
+                    ? 'bg-gradient-to-r from-red-400 to-red-500' 
+                    : 'bg-gradient-to-r from-yellow-400 to-yellow-500'
+                }`}
+                initial={{ width: 0 }}
+                animate={{ width: `${getProgressPercentage()}%` }}
+                transition={{ duration: 0.5, ease: "easeOut" }}
+              />
+            </div>
+            <p className="text-sm text-white/80 mt-2 lego-text">
+              {getProgressPercentage()}% Complete
+            </p>
+          </div>
+
+          {/* Loading steps indicator */}
+          <div className="grid grid-cols-2 gap-3 text-xs">
+            {[
+              { key: 'instances', label: 'Instances', icon: '🎮' },
+              { key: 'provisionedInstances', label: 'Ready Nodes', icon: '✅' },
+              { key: 'hotkeys', label: 'Controls', icon: '⌨️' },
+              { key: 'status', label: 'Status', icon: '📊' }
+            ].map(({ key, label, icon }) => (
+              <motion.div
+                key={key}
+                className={`
+                  flex items-center space-x-2 p-2 rounded-lg
+                  ${!loadingStates[key] 
+                    ? 'bg-green-500/30 text-white' 
+                    : errors[key]
+                      ? 'bg-red-500/30 text-red-200'
+                      : 'bg-white/10 text-white/70'
+                  }
+                `}
+                initial={{ x: -20, opacity: 0 }}
+                animate={{ x: 0, opacity: 1 }}
+                transition={{ delay: 0.4 + (Object.keys(loadingStates).indexOf(key) * 0.1) }}
+              >
+                <span className="text-sm">{icon}</span>
+                <span className="lego-text font-bold">{label}</span>
+                {!loadingStates[key] && !errors[key] && (
+                  <motion.span
+                    className="text-green-300"
+                    initial={{ scale: 0 }}
+                    animate={{ scale: 1 }}
+                    transition={{ type: "spring", stiffness: 200 }}
+                  >
+                    ✓
+                  </motion.span>
+                )}
+                {errors[key] && (
+                  <motion.span
+                    className="text-red-300"
+                    animate={{ rotate: [0, 10, -10, 0] }}
+                    transition={{ repeat: Infinity, duration: 2 }}
+                  >
+                    ⚠️
+                  </motion.span>
+                )}
+              </motion.div>
+            ))}
+          </div>
+
+          {/* Error message */}
+          {hasErrors && (
+            <motion.div
+              className="mt-6 p-4 bg-red-500/20 border border-red-400/30 rounded-lg"
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+            >
+              <p className="text-red-200 text-sm lego-text">
+                ⚠️ Some data couldn't be loaded. The app will work with limited functionality.
+              </p>
+            </motion.div>
+          )}
+        </motion.div>
+
+        {/* LEGO brick decorations */}
+        {Array(6).fill(0).map((_, i) => (
+          <motion.div
+            key={i}
+            className="absolute w-8 h-8 bg-white/10 rounded border-2 border-white/20"
+            style={{
+              left: `${10 + i * 15}%`,
+              top: `${20 + (i % 2) * 60}%`,
+            }}
+            animate={{ 
+              y: [0, -10, 0],
+              rotate: [0, 180, 360] 
+            }}
+            transition={{ 
+              repeat: Infinity, 
+              duration: 4 + i, 
+              ease: "easeInOut" 
+            }}
+          >
+            <div className="grid grid-cols-2 gap-1 p-1">
+              {Array(4).fill(0).map((_, j) => (
+                <div key={j} className="w-1 h-1 bg-white/30 rounded-full" />
+              ))}
+            </div>
+          </motion.div>
+        ))}
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/components/LoadingSpinner.jsx
+++ b/frontend/src/components/LoadingSpinner.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+/**
+ * Reusable loading spinner component with LEGO theming
+ * Props:
+ * - size: 'sm' | 'md' | 'lg' (default: 'md')
+ * - message: Optional loading message to display
+ * - className: Additional CSS classes
+ * - variant: 'primary' | 'secondary' | 'light' (default: 'primary')
+ */
+export default function LoadingSpinner({ 
+  size = 'md', 
+  message, 
+  className = '', 
+  variant = 'primary' 
+}) {
+  const sizeClasses = {
+    sm: 'w-6 h-6',
+    md: 'w-10 h-10', 
+    lg: 'w-16 h-16'
+  };
+
+  const colorClasses = {
+    primary: 'border-yellow-400 border-t-red-600',
+    secondary: 'border-blue-400 border-t-green-500',
+    light: 'border-white/50 border-t-white'
+  };
+
+  const textSizeClasses = {
+    sm: 'text-xs',
+    md: 'text-sm',
+    lg: 'text-base'
+  };
+
+  const textColorClasses = {
+    primary: 'text-yellow-400',
+    secondary: 'text-blue-400', 
+    light: 'text-white'
+  };
+
+  return (
+    <div className={`flex flex-col items-center justify-center ${className}`}>
+      {/* LEGO-themed spinning loader */}
+      <motion.div
+        className={`
+          ${sizeClasses[size]} 
+          border-3 ${colorClasses[variant]} 
+          rounded-full shadow-lg
+        `}
+        animate={{ rotate: 360 }}
+        transition={{ 
+          repeat: Infinity, 
+          duration: 1, 
+          ease: "linear" 
+        }}
+      />
+      
+      {/* LEGO brick dots overlay for authentic feel */}
+      <motion.div
+        className={`
+          absolute ${sizeClasses[size]}
+          flex items-center justify-center
+        `}
+        animate={{ scale: [1, 1.1, 1] }}
+        transition={{ 
+          repeat: Infinity, 
+          duration: 2, 
+          ease: "easeInOut" 
+        }}
+      >
+        <div className="grid grid-cols-2 gap-1">
+          {[...Array(4)].map((_, i) => (
+            <motion.div
+              key={i}
+              className={`w-1 h-1 rounded-full ${
+                variant === 'light' ? 'bg-white/30' : 'bg-black/20'
+              }`}
+              animate={{ opacity: [0.3, 1, 0.3] }}
+              transition={{ 
+                repeat: Infinity, 
+                duration: 1.5, 
+                delay: i * 0.1,
+                ease: "easeInOut" 
+              }}
+            />
+          ))}
+        </div>
+      </motion.div>
+
+      {/* Loading message */}
+      {message && (
+        <motion.p 
+          className={`
+            mt-3 font-bold lego-text tracking-wide
+            ${textSizeClasses[size]} 
+            ${textColorClasses[variant]}
+          `}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2 }}
+        >
+          {message}
+        </motion.p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useProgressiveLoading.js
+++ b/frontend/src/hooks/useProgressiveLoading.js
@@ -1,0 +1,156 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { fetchLiveInstances } from '../api/discovery';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('useProgressiveLoading');
+
+const POLL_INTERVAL_MS = 5000;
+
+/**
+ * Progressive data loading for the dashboard (concept from PR #74).
+ *
+ * Phase 1 (critical): live instances via the discovery API — the 3×3 grid
+ * renders as soon as this resolves.
+ * Phase 2 (secondary): hotkey config and cluster status — fetched after the
+ * critical phase settles so they never block first paint.
+ *
+ * Also owns the 5s polling loop and the `discoveryRefreshed` listener that
+ * App.jsx previously wired inline.
+ */
+export default function useProgressiveLoading() {
+  const [instances, setInstances] = useState([]);
+  const [provisionedInstances, setProvisionedInstances] = useState([]);
+  const [discoveryStatus, setDiscoveryStatus] = useState(null);
+  const [hotkeys, setHotkeys] = useState({});
+  const [status, setStatus] = useState({});
+
+  const [loadingStates, setLoadingStates] = useState({
+    instances: true,
+    provisionedInstances: true,
+    hotkeys: true,
+    status: true,
+    initialLoad: true,
+  });
+  const [errors, setErrors] = useState({});
+  const mountedRef = useRef(true);
+
+  const setLoading = useCallback((key, isLoading) => {
+    setLoadingStates((prev) => ({ ...prev, [key]: isLoading }));
+  }, []);
+
+  const setError = useCallback((key, error) => {
+    setErrors((prev) => ({ ...prev, [key]: error }));
+  }, []);
+
+  const clearError = useCallback((key) => {
+    setErrors((prev) => {
+      if (!(key in prev)) return prev;
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  }, []);
+
+  // Phase 1 — critical: instances (provisioned list is derived client-side)
+  const loadInstances = useCallback(async () => {
+    try {
+      const data = await fetchLiveInstances();
+      if (!mountedRef.current) return;
+      const list = data.instances || [];
+      setInstances(list);
+      setDiscoveryStatus(data);
+      setProvisionedInstances(list.filter((i) => i.provisioned || i.status === 'ready'));
+      clearError('instances');
+      clearError('provisionedInstances');
+    } catch (e) {
+      if (!mountedRef.current) return;
+      logger.error('Failed to fetch live instances', { error: e.message });
+      setError('instances', e);
+      setError('provisionedInstances', e);
+    } finally {
+      if (mountedRef.current) {
+        setLoading('instances', false);
+        setLoading('provisionedInstances', false);
+      }
+    }
+  }, [clearError, setError, setLoading]);
+
+  // Phase 2 — secondary: hotkeys (once) and status
+  const loadHotkeys = useCallback(async () => {
+    try {
+      const r = await fetch('/api/config/hotkeys');
+      const data = await r.json();
+      if (mountedRef.current) {
+        setHotkeys(data);
+        clearError('hotkeys');
+      }
+    } catch (e) {
+      if (!mountedRef.current) return;
+      logger.warn('Failed to fetch hotkeys', { error: e.message });
+      setError('hotkeys', e);
+    } finally {
+      if (mountedRef.current) setLoading('hotkeys', false);
+    }
+  }, [clearError, setError, setLoading]);
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const r = await fetch('/api/status');
+      const data = await r.json();
+      if (mountedRef.current) {
+        setStatus(data);
+        clearError('status');
+      }
+    } catch (e) {
+      if (!mountedRef.current) return;
+      logger.warn('Failed to fetch status', { error: e.message });
+      setError('status', e);
+    } finally {
+      if (mountedRef.current) setLoading('status', false);
+    }
+  }, [clearError, setError, setLoading]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    // Critical first; secondary starts only after critical settles so it
+    // cannot compete for the connection during first paint.
+    loadInstances().then(() => {
+      if (!mountedRef.current) return;
+      setLoading('initialLoad', false);
+      loadHotkeys();
+      loadStatus();
+    });
+
+    const interval = setInterval(() => {
+      loadInstances();
+      loadStatus();
+    }, POLL_INTERVAL_MS);
+
+    const handleDiscoveryRefresh = () => {
+      logger.info('Discovery refreshed, reloading instances');
+      loadInstances();
+    };
+    window.addEventListener('discoveryRefreshed', handleDiscoveryRefresh);
+
+    return () => {
+      mountedRef.current = false;
+      clearInterval(interval);
+      window.removeEventListener('discoveryRefreshed', handleDiscoveryRefresh);
+    };
+  }, [loadInstances, loadHotkeys, loadStatus, setLoading]);
+
+  const isCriticalDataLoaded = !loadingStates.instances;
+
+  return {
+    instances,
+    provisionedInstances,
+    discoveryStatus,
+    hotkeys,
+    status,
+    loadingStates,
+    errors,
+    isCriticalDataLoaded,
+    reloadInstances: loadInstances,
+  };
+}

--- a/frontend/src/hooks/useProgressiveLoading.test.jsx
+++ b/frontend/src/hooks/useProgressiveLoading.test.jsx
@@ -1,0 +1,119 @@
+/**
+ * Tests for the progressive loading hook: phase ordering, error handling,
+ * and cleanup. Uses jsdom + mocked fetch/discovery API.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+vi.mock('../api/discovery', () => ({
+  fetchLiveInstances: vi.fn(),
+}));
+
+import { fetchLiveInstances } from '../api/discovery';
+import useProgressiveLoading from './useProgressiveLoading';
+
+const INSTANCES = [
+  { id: 'instance-0', status: 'ready', provisioned: true },
+  { id: 'instance-1', status: 'booting', provisioned: false },
+];
+
+describe('useProgressiveLoading', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    fetchLiveInstances.mockResolvedValue({ instances: INSTANCES, mode: 'kubernetes-pods' });
+    global.fetch = vi.fn((url) => {
+      if (url === '/api/config/hotkeys') {
+        return Promise.resolve({ json: () => Promise.resolve({ next: 'ctrl+tab' }) });
+      }
+      if (url === '/api/status') {
+        return Promise.resolve({ json: () => Promise.resolve({ healthy: true }) });
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`));
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('loads critical data first, then secondary data', async () => {
+    const { result } = renderHook(() => useProgressiveLoading());
+
+    expect(result.current.loadingStates.initialLoad).toBe(true);
+
+    await waitFor(() => expect(result.current.isCriticalDataLoaded).toBe(true));
+    expect(result.current.instances).toHaveLength(2);
+    expect(result.current.provisionedInstances).toHaveLength(1);
+    expect(result.current.loadingStates.initialLoad).toBe(false);
+
+    // Secondary phase starts only after critical settles
+    await waitFor(() => expect(result.current.loadingStates.hotkeys).toBe(false));
+    await waitFor(() => expect(result.current.loadingStates.status).toBe(false));
+    expect(result.current.hotkeys).toEqual({ next: 'ctrl+tab' });
+    expect(result.current.status).toEqual({ healthy: true });
+  });
+
+  it('secondary fetches do not fire before the critical phase settles', async () => {
+    let resolveCritical;
+    fetchLiveInstances.mockReturnValue(new Promise((res) => { resolveCritical = res; }));
+
+    renderHook(() => useProgressiveLoading());
+
+    // Critical still pending — no secondary fetches yet
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveCritical({ instances: INSTANCES });
+    });
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/config/hotkeys'));
+  });
+
+  it('records an error but completes the phase when the discovery API fails', async () => {
+    fetchLiveInstances.mockRejectedValue(new Error('api down'));
+
+    const { result } = renderHook(() => useProgressiveLoading());
+
+    await waitFor(() => expect(result.current.loadingStates.instances).toBe(false));
+    expect(result.current.errors.instances).toBeDefined();
+    expect(result.current.instances).toEqual([]);
+    // The overlay can dismiss — initial load still completes
+    await waitFor(() => expect(result.current.loadingStates.initialLoad).toBe(false));
+  });
+
+  it('reloads instances when a discoveryRefreshed event fires', async () => {
+    const { result } = renderHook(() => useProgressiveLoading());
+    await waitFor(() => expect(result.current.isCriticalDataLoaded).toBe(true));
+
+    fetchLiveInstances.mockClear();
+    act(() => {
+      window.dispatchEvent(new Event('discoveryRefreshed'));
+    });
+
+    await waitFor(() => expect(fetchLiveInstances).toHaveBeenCalled());
+  });
+
+  it('polls instances and status on the interval', async () => {
+    const { result } = renderHook(() => useProgressiveLoading());
+    await waitFor(() => expect(result.current.loadingStates.status).toBe(false));
+
+    fetchLiveInstances.mockClear();
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+    await waitFor(() => expect(fetchLiveInstances).toHaveBeenCalled());
+  });
+
+  it('stops polling after unmount', async () => {
+    const { result, unmount } = renderHook(() => useProgressiveLoading());
+    await waitFor(() => expect(result.current.isCriticalDataLoaded).toBe(true));
+
+    unmount();
+    fetchLiveInstances.mockClear();
+    await act(async () => {
+      vi.advanceTimersByTime(15000);
+    });
+    expect(fetchLiveInstances).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Third salvage item from the draft-PR adoption assessment: #74's progressive loading, rewritten on today's discovery API.

- **Two-phase loading**: instance grid renders as soon as `fetchLiveInstances` resolves; hotkeys/status fetch afterwards — first paint is never blocked by secondary data. Verified by a test that holds the critical fetch open and asserts no secondary fetch fires.
- **LEGO-themed `AppLoadingOverlay` + `LoadingSpinner`** ported from #74 (progress bar, per-step ✓/⚠ indicators, error fallback messaging).
- The hook now owns the polling loop + `discoveryRefreshed` listener that previously lived inline in App.jsx; errors go through the structured frontend logger instead of `console.error`.
- **nginx gzip** in both config variants (immutable 1y asset caching already existed).
- 6 new tests with @testing-library/react. Suite: **42/42**, production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)