### PR TITLE
feat(backend): helmet, API rate limiting, SLA scoring + webhook alerts (adopts #82's concepts)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@kubernetes/client-node": "^1.3.0",
     "express": "^4.18.2",
+    "helmet": "^8.0.0",
     "http-proxy": "^1.18.1",
     "opossum": "^8.1.4",
     "prom-client": "^15.1.0",

--- a/backend/server.js
+++ b/backend/server.js
@@ -33,13 +33,39 @@ const StreamQualityMonitor = require("./services/streamQualityMonitor");
 const InstanceManager = require("./services/instanceManager");
 const rateLimit = require("./utils/rateLimit");
 const validate = require("./utils/validate");
+const helmet = require("helmet");
 
 // Rate limiters
 const writeRateLimit = rateLimit({ windowMs: 60_000, max: 30 });   // 30 req/min for general POST
 const criticalRateLimit = rateLimit({ windowMs: 60_000, max: 5 });  // 5 req/min for recovery/restart
+// Broad read-path limiter (concept from #82). Generous: the dashboard polls
+// several endpoints every 5s per client. Override via API_RATE_LIMIT_MAX.
+const apiReadRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: parseInt(process.env.API_RATE_LIMIT_MAX || '600', 10),
+});
 
 const app = express();
 const server = http.createServer(app);
+
+// Security headers (concept from #82). CSP is disabled: this server only
+// speaks JSON/WebSocket behind the nginx frontend, and a strict CSP here
+// would apply to proxied content it does not own.
+app.use(helmet({ contentSecurityPolicy: false }));
+
+// Rate-limit the API surface, but never the kubelet probe or metrics paths —
+// throttling liveness probes would turn load into restarts.
+app.use((req, res, next) => {
+  if (
+    req.path === '/health' ||
+    req.path === '/ready' ||
+    req.path === '/metrics' ||
+    !req.path.startsWith('/api/')
+  ) {
+    return next();
+  }
+  return apiReadRateLimit(req, res, next);
+});
 
 // Global error handlers
 process.on('uncaughtException', (err) => {

--- a/backend/services/streamQualityMonitor.js
+++ b/backend/services/streamQualityMonitor.js
@@ -23,6 +23,12 @@ class StreamQualityMonitor {
     this.isRunning = false;
     this.recoveryAttempts = new Map(); // instanceId -> attempts count
     this.maxRecoveryAttempts = 3;
+
+    // SLA scoring + alerting (concept from PR #82)
+    this.slaAlertThreshold = parseInt(process.env.SLA_ALERT_THRESHOLD || '70', 10);
+    this.alertWebhookUrl = process.env.ALERT_WEBHOOK_URL || null;
+    this.alertCooldownMs = parseInt(process.env.SLA_ALERT_COOLDOWN_MS || '300000', 10);
+    this.lastAlertAt = new Map(); // instanceId -> timestamp of last alert
   }
 
   /**
@@ -129,6 +135,8 @@ class StreamQualityMonitor {
       // Update metrics map
       results.forEach(metrics => {
         if (metrics && metrics.instanceId) {
+          metrics.slaScore = this.computeSlaScore(metrics);
+          this.evaluateSlaAlert(metrics);
           this.metrics.set(metrics.instanceId, metrics);
         }
       });
@@ -719,6 +727,65 @@ class StreamQualityMonitor {
   }
 
   /**
+   * Compute a 0-100 SLA score for one instance's metrics (concept from #82).
+   * Weights: availability 50 (vnc 25, stream 10, audio 10, controls 5),
+   * latency 30 (full marks <=100 ms, linear falloff to 0 at 1000 ms),
+   * video frame rate 20 (full marks at >=15 fps).
+   */
+  computeSlaScore(metrics) {
+    let score = 0;
+    const a = metrics.availability || {};
+    if (a.vnc) score += 25;
+    if (a.stream) score += 10;
+    if (a.audio) score += 10;
+    if (a.controls) score += 5;
+
+    const latency = metrics.quality ? metrics.quality.connectionLatency : null;
+    if (latency !== null && latency !== undefined) {
+      score += latency <= 100 ? 30 : Math.max(0, Math.round(30 * (1 - (latency - 100) / 900)));
+    }
+
+    const fps = (metrics.quality && metrics.quality.videoFrameRate) || 0;
+    score += Math.min(20, Math.round((fps / 15) * 20));
+
+    return Math.min(100, score);
+  }
+
+  /**
+   * Fire a webhook alert (with per-instance cooldown) when an instance's
+   * SLA score degrades below the threshold. No-op without ALERT_WEBHOOK_URL.
+   */
+  evaluateSlaAlert(metrics) {
+    if (!this.alertWebhookUrl) return;
+    if (metrics.slaScore >= this.slaAlertThreshold) return;
+
+    const now = Date.now();
+    const last = this.lastAlertAt.get(metrics.instanceId) || 0;
+    if (now - last < this.alertCooldownMs) return;
+    this.lastAlertAt.set(metrics.instanceId, now);
+
+    const payload = {
+      type: 'sla_degraded',
+      instanceId: metrics.instanceId,
+      slaScore: metrics.slaScore,
+      threshold: this.slaAlertThreshold,
+      availability: metrics.availability,
+      latencyMs: metrics.quality ? metrics.quality.connectionLatency : null,
+      timestamp: new Date(now).toISOString(),
+    };
+
+    fetch(this.alertWebhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }).then(() => {
+      logger.warn('SLA alert sent', { instanceId: metrics.instanceId, slaScore: metrics.slaScore });
+    }).catch((err) => {
+      logger.error('SLA alert webhook failed', { error: err.message });
+    });
+  }
+
+  /**
    * Get quality summary for all instances
    */
   getQualitySummary() {
@@ -751,11 +818,22 @@ class StreamQualityMonitor {
       return dist;
     }, {});
 
+    const slaScores = instances
+      .map(m => m.slaScore)
+      .filter(s => s !== null && s !== undefined);
+    const averageSlaScore = slaScores.length > 0
+      ? Math.round(slaScores.reduce((x, y) => x + y, 0) / slaScores.length)
+      : null;
+
     return {
       total,
       available,
       availabilityPercent: (available / total) * 100,
       averageLatency: averageLatency ? Math.round(averageLatency) : null,
+      averageSlaScore,
+      degradedInstances: instances
+        .filter(m => (m.slaScore ?? 100) < this.slaAlertThreshold)
+        .map(m => ({ instanceId: m.instanceId, slaScore: m.slaScore })),
       qualityDistribution
     };
   }

--- a/backend/tests/slaScoring.test.js
+++ b/backend/tests/slaScoring.test.js
@@ -1,0 +1,116 @@
+const StreamQualityMonitor = require('../services/streamQualityMonitor');
+
+describe('SLA scoring (streamQualityMonitor)', () => {
+  let monitor;
+
+  beforeEach(() => {
+    monitor = new StreamQualityMonitor('../config', null);
+  });
+
+  afterEach(() => {
+    monitor.stop();
+  });
+
+  const fullMetrics = () => ({
+    instanceId: 'instance-0',
+    availability: { vnc: true, stream: true, audio: true, controls: true },
+    quality: { connectionLatency: 50, videoFrameRate: 25 },
+  });
+
+  test('perfect instance scores 100', () => {
+    expect(monitor.computeSlaScore(fullMetrics())).toBe(100);
+  });
+
+  test('vnc-down instance loses availability points', () => {
+    const m = fullMetrics();
+    m.availability = { vnc: false, stream: false, audio: false, controls: false };
+    // latency 30 + fps 20 remain
+    expect(monitor.computeSlaScore(m)).toBe(50);
+  });
+
+  test('latency degrades score linearly past 100ms', () => {
+    const m = fullMetrics();
+    m.quality.connectionLatency = 550; // halfway between 100 and 1000
+    expect(monitor.computeSlaScore(m)).toBe(85); // 50 avail + 15 latency + 20 fps
+  });
+
+  test('latency past 1000ms earns zero latency points', () => {
+    const m = fullMetrics();
+    m.quality.connectionLatency = 5000;
+    expect(monitor.computeSlaScore(m)).toBe(70);
+  });
+
+  test('missing latency contributes nothing', () => {
+    const m = fullMetrics();
+    m.quality.connectionLatency = null;
+    expect(monitor.computeSlaScore(m)).toBe(70);
+  });
+
+  test('frame rate scales to 20 points at 15fps', () => {
+    const m = fullMetrics();
+    m.quality.videoFrameRate = 7.5;
+    expect(monitor.computeSlaScore(m)).toBe(90); // 50 + 30 + 10
+  });
+
+  test('summary aggregates average SLA and lists degraded instances', () => {
+    const good = fullMetrics();
+    good.slaScore = monitor.computeSlaScore(good);
+
+    const bad = fullMetrics();
+    bad.instanceId = 'instance-1';
+    bad.availability = { vnc: false, stream: false, audio: false, controls: false };
+    bad.quality = { connectionLatency: null, videoFrameRate: 0 };
+    bad.slaScore = monitor.computeSlaScore(bad);
+
+    monitor.metrics.set('instance-0', good);
+    monitor.metrics.set('instance-1', bad);
+
+    const summary = monitor.getQualitySummary();
+    expect(summary.averageSlaScore).toBe(50); // (100 + 0) / 2
+    expect(summary.degradedInstances).toEqual([
+      { instanceId: 'instance-1', slaScore: 0 },
+    ]);
+  });
+
+  test('alert webhook fires below threshold and respects cooldown', async () => {
+    monitor.alertWebhookUrl = 'http://alerts.example/hook';
+    monitor.slaAlertThreshold = 70;
+    global.fetch = jest.fn().mockResolvedValue({ ok: true });
+
+    const bad = fullMetrics();
+    bad.slaScore = 10;
+
+    monitor.evaluateSlaAlert(bad);
+    monitor.evaluateSlaAlert(bad); // within cooldown — must not re-fire
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = global.fetch.mock.calls[0];
+    expect(url).toBe('http://alerts.example/hook');
+    const payload = JSON.parse(opts.body);
+    expect(payload.type).toBe('sla_degraded');
+    expect(payload.instanceId).toBe('instance-0');
+    expect(payload.slaScore).toBe(10);
+  });
+
+  test('no webhook configured means no alert attempt', () => {
+    monitor.alertWebhookUrl = null;
+    global.fetch = jest.fn();
+
+    const bad = fullMetrics();
+    bad.slaScore = 10;
+    monitor.evaluateSlaAlert(bad);
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('healthy score above threshold does not alert', () => {
+    monitor.alertWebhookUrl = 'http://alerts.example/hook';
+    global.fetch = jest.fn();
+
+    const good = fullMetrics();
+    good.slaScore = 95;
+    monitor.evaluateSlaAlert(good);
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fourth salvage item from the draft-PR adoption assessment: the worthwhile parts of #82, folded into existing services instead of new parallel ones.

- **helmet** security headers (CSP off — JSON/WS API behind nginx).
- **/api/\* rate limiting** via the existing homegrown sliding-window limiter (600/min default, env-overridable) with probe/metrics paths exempt so kubelet is never throttled.
- **SLA scoring (0–100)** per instance in `streamQualityMonitor` — availability 50 / latency 30 / frame-rate 20 — surfaced in `/api/quality/summary` as `averageSlaScore` + `degradedInstances`.
- **Webhook alerting** with per-instance cooldown when a score drops below threshold (`ALERT_WEBHOOK_URL`, `SLA_ALERT_THRESHOLD`, `SLA_ALERT_COOLDOWN_MS`).
- Deliberately skipped from #82: in-backend auto-restart (fights kubelet), the standalone enterprise monitor service (its detection fixes already landed via the consolidation), API keys.
- 10 new tests; backend suite 73 passed / 9 failed (same 9 pre-existing infra-dependent failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)