### PR TITLE
feat(devx): one-command LAN game startup with proof capture

### DIFF
--- a/docs/LAN_MULTIPLAYER_AND_GHCR_RUNBOOK.md
+++ b/docs/LAN_MULTIPLAYER_AND_GHCR_RUNBOOK.md
@@ -10,6 +10,33 @@
 
 ---
 
+## Quickstart (one command)
+
+Once the network-ready emulator image exists locally (built + baked per §2),
+the whole flow is wrapped by a single script:
+
+```bash
+# Cluster up → build/load images → deploy 2-instance LAN → drive both guests
+# into a TCP multiplayer game → capture proof screendumps under proof/
+scripts/start-lan-game.sh
+
+# Also record the dashboard's progressive loading as video evidence:
+scripts/start-lan-game.sh --record
+
+# Reuse an existing cluster/images, deploy-and-wait only (no in-game steps):
+scripts/start-lan-game.sh --skip-cluster --skip-build --skip-game
+```
+
+The in-game choreography lives in editable step files
+(`scripts/lan-game-steps/{host-create,guest-join}.steps`) run by
+`scripts/lan-game-steps.py` — a data-driven QMP runner (`hmp` / `loadvm` /
+`sleep` / `dump`). If the guests lack a baked `mainmenu` savevm, `loadvm`
+degrades gracefully and the script continues from whatever state the guests
+booted into. The manual bring-up below (§1–§5) is the source of truth those
+step files were recorded from.
+
+---
+
 ## 0. TL;DR / mental model
 
 - Each emulator pod runs **QEMU (`qemu-system-i386`, TCG)** booting a Win98 SE qcow2.

--- a/helm/loco-chart/templates/emulator-statefulset.yaml
+++ b/helm/loco-chart/templates/emulator-statefulset.yaml
@@ -6,11 +6,13 @@ metadata:
 spec:
   serviceName: {{ include "loco.fullname" . }}-emulator
   replicas: {{ .Values.replicas }}
-  # Zero-downtime rolling update strategy
+  # Zero-downtime rolling update strategy.
+  # NOTE: rollingUpdate.maxUnavailable is intentionally omitted — for
+  # StatefulSets it requires the MaxUnavailableStatefulSet feature gate
+  # (alpha, k8s >=1.24) and fails `helm upgrade`/`kubectl apply` validation
+  # outright on older clusters (Docker Desktop 1.19, kind 1.27).
   updateStrategy:
     type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
   selector:
     matchLabels:
       app: {{ include "loco.fullname" . }}-emulator

--- a/scripts/lan-game-steps.py
+++ b/scripts/lan-game-steps.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Drive Win98 guests into a Lego Loco LAN game via QMP, with proof capture.
+
+Executes step files against emulator pods using `kubectl exec` and the
+qmp-control.py helper baked into the emulator image. Step files are plain
+text, one command per line (`#` comments allowed):
+
+    <instance> hmp <monitor command...>   raw HMP (mouse_move, sendkey, ...)
+    <instance> loadvm <tag>               restore a savevm snapshot
+    <instance> sleep <seconds>            wait
+    <instance> dump <label>               screendump -> proof dir (ppm + png)
+
+The shipped host-create/guest-join step files encode the choreography from
+docs/LAN_MULTIPLAYER_AND_GHCR_RUNBOOK.md §2.4 at 1024x768. Coordinates are
+resolution-dependent — recapture with `dump` steps if the layout changes.
+"""
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+QMP_HELPER = "/usr/local/bin/qmp-control.py"
+
+
+def kubectl_exec(namespace, pod, *cmd, check=True):
+    full = ["kubectl", "exec", "-n", namespace, pod, "--", *cmd]
+    result = subprocess.run(full, capture_output=True, text=True, timeout=120)
+    if check and result.returncode != 0:
+        raise RuntimeError(f"{' '.join(full)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def pod_name(namespace, index):
+    return f"loco-loco-emulator-{index}"
+
+
+def screendump(namespace, pod, label, proof_dir):
+    remote = f"/tmp/proof-{label}.ppm"
+    kubectl_exec(namespace, pod, "python3", QMP_HELPER, "hmp", f"screendump {remote}")
+    time.sleep(1)
+    local_ppm = proof_dir / f"{pod}-{label}.ppm"
+    subprocess.run(
+        ["kubectl", "cp", "-n", namespace, f"{pod}:{remote.lstrip('/')}", str(local_ppm)],
+        capture_output=True, text=True, timeout=120,
+    )
+    if not local_ppm.exists():
+        print(f"  WARNING: could not copy {remote} from {pod}")
+        return
+    try:
+        from PIL import Image
+        png = local_ppm.with_suffix(".png")
+        Image.open(local_ppm).save(png)
+        local_ppm.unlink()
+        print(f"  proof: {png}")
+    except ImportError:
+        print(f"  proof: {local_ppm} (install pillow for png conversion)")
+
+
+def run_steps(namespace, steps_file, proof_dir, label):
+    print(f"--- running {steps_file} ({label})")
+    for raw in Path(steps_file).read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(None, 2)
+        idx, cmd = parts[0], parts[1]
+        arg = parts[2] if len(parts) > 2 else ""
+        pod = pod_name(namespace, idx)
+
+        if cmd == "sleep":
+            time.sleep(float(arg))
+        elif cmd == "hmp":
+            out = kubectl_exec(namespace, pod, "python3", QMP_HELPER, "hmp", arg)
+            if '"error"' in out:
+                print(f"  WARNING [{pod}] hmp {arg}: {out.strip()[:120]}")
+        elif cmd == "loadvm":
+            print(f"  [{pod}] loadvm {arg}")
+            out = kubectl_exec(namespace, pod, "python3", QMP_HELPER, "loadvm", arg, check=False)
+            if '"error"' in out:
+                print(f"  WARNING [{pod}] loadvm {arg} failed — continuing from live state")
+        elif cmd == "dump":
+            screendump(namespace, pod, arg, proof_dir)
+        else:
+            print(f"  WARNING: unknown step command: {line}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--namespace", default="loco")
+    ap.add_argument("--proof-dir", default="proof")
+    ap.add_argument("--host-steps", required=True)
+    ap.add_argument("--guest-steps", required=True)
+    ap.add_argument("--settle", type=float, default=8.0,
+                    help="seconds to wait between host-create and guest-join")
+    args = ap.parse_args()
+
+    proof_dir = Path(args.proof_dir)
+    proof_dir.mkdir(parents=True, exist_ok=True)
+
+    run_steps(args.namespace, args.host_steps, proof_dir, "host creates LAN game")
+    print(f"--- waiting {args.settle}s for the session to open")
+    time.sleep(args.settle)
+    run_steps(args.namespace, args.guest_steps, proof_dir, "guest joins LAN game")
+
+    # Final proof: both screens after the join settles
+    time.sleep(10)
+    for idx in (0, 1):
+        screendump(args.namespace, pod_name(args.namespace, idx), "final", proof_dir)
+
+    print("--- LAN game choreography complete")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lan-game-steps/guest-join.steps
+++ b/scripts/lan-game-steps/guest-join.steps
@@ -1,0 +1,40 @@
+# Instance 1: from the Lego Loco main menu, join the hosted TCP game.
+# Coordinates recorded during the original proof session (scripts/qmp-steps.txt):
+# join = binoculars, lower red button ~(828,490) at 1024x768.
+1 loadvm mainmenu
+1 sleep 5
+1 dump guest-mainmenu
+# Click the multiplayer briefcase
+1 hmp mouse_move -3000 -3000
+1 sleep 1
+1 hmp mouse_move 512 430
+1 sleep 1
+1 hmp mouse_button 1
+1 hmp mouse_button 0
+1 sleep 4
+1 dump guest-multiplayer-menu
+# Join game (binoculars, lower red button)
+1 hmp mouse_move -3000 -3000
+1 sleep 1
+1 hmp mouse_move 828 490
+1 sleep 1
+1 hmp mouse_button 1
+1 hmp mouse_button 0
+1 sleep 4
+1 dump guest-join-dialog
+# Select TCP transport and confirm (green check)
+1 hmp mouse_move -3000 -3000
+1 sleep 1
+1 hmp mouse_move 512 400
+1 sleep 1
+1 hmp mouse_button 1
+1 hmp mouse_button 0
+1 sleep 2
+1 hmp mouse_move -3000 -3000
+1 sleep 1
+1 hmp mouse_move 620 520
+1 sleep 1
+1 hmp mouse_button 1
+1 hmp mouse_button 0
+1 sleep 8
+1 dump guest-searching-or-lobby

--- a/scripts/lan-game-steps/host-create.steps
+++ b/scripts/lan-game-steps/host-create.steps
@@ -1,0 +1,41 @@
+# Instance 0: from the Lego Loco main menu, host a TCP LAN game.
+# Layout reference: 1024x768, savevm tag "mainmenu" taken at the main menu
+# (docs/LAN_MULTIPLAYER_AND_GHCR_RUNBOOK.md §2.4). The multiplayer briefcase
+# is the two-figure case; the pencil button creates a game.
+0 loadvm mainmenu
+0 sleep 5
+0 dump host-mainmenu
+# Park the cursor at a known corner, then click the multiplayer briefcase
+0 hmp mouse_move -3000 -3000
+0 sleep 1
+0 hmp mouse_move 512 430
+0 sleep 1
+0 hmp mouse_button 1
+0 hmp mouse_button 0
+0 sleep 4
+0 dump host-multiplayer-menu
+# Create game (pencil, upper action button on the right panel)
+0 hmp mouse_move -3000 -3000
+0 sleep 1
+0 hmp mouse_move 828 410
+0 sleep 1
+0 hmp mouse_button 1
+0 hmp mouse_button 0
+0 sleep 4
+0 dump host-create-dialog
+# Select TCP transport and confirm (green check)
+0 hmp mouse_move -3000 -3000
+0 sleep 1
+0 hmp mouse_move 512 400
+0 sleep 1
+0 hmp mouse_button 1
+0 hmp mouse_button 0
+0 sleep 2
+0 hmp mouse_move -3000 -3000
+0 sleep 1
+0 hmp mouse_move 620 520
+0 sleep 1
+0 hmp mouse_button 1
+0 hmp mouse_button 0
+0 sleep 6
+0 dump host-lobby

--- a/scripts/record-progressive-loading.js
+++ b/scripts/record-progressive-loading.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * record-progressive-loading.js — capture the dashboard's progressive
+ * loading experience (AppLoadingOverlay -> instance grid) as video evidence.
+ *
+ * Recording starts BEFORE navigation so the overlay phase is fully captured,
+ * and the browser runs with a throttled network profile so the two loading
+ * phases are visible rather than instantaneous.
+ *
+ * Usage:
+ *   node scripts/record-progressive-loading.js [--url http://localhost:3000]
+ *     [--out proof/] [--duration 15000] [--latency 150]
+ *
+ * Outputs in --out:
+ *   progressive-loading.webm            screen recording
+ *   progressive-loading-overlay.png     overlay phase screenshot
+ *   progressive-loading-loaded.png      loaded dashboard screenshot
+ */
+
+const { chromium } = require('playwright');
+const path = require('path');
+const fs = require('fs');
+
+async function main() {
+  const args = process.argv.slice(2);
+  let url = 'http://localhost:3000';
+  let outDir = path.join(__dirname, '..', 'proof');
+  let duration = 15000;
+  let latency = 150;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--url' && args[i + 1]) url = args[i + 1];
+    if (args[i] === '--out' && args[i + 1]) outDir = path.resolve(args[i + 1]);
+    if (args[i] === '--duration' && args[i + 1]) duration = parseInt(args[i + 1], 10);
+    if (args[i] === '--latency' && args[i + 1]) latency = parseInt(args[i + 1], 10);
+  }
+
+  fs.mkdirSync(outDir, { recursive: true });
+
+  console.log(`🎬 Recording progressive loading from ${url}`);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 800 },
+    recordVideo: { dir: outDir, size: { width: 1280, height: 800 } },
+  });
+
+  const page = await context.newPage();
+
+  // Throttle API responses so both loading phases are observable
+  const cdp = await context.newCDPSession(page);
+  await cdp.send('Network.emulateNetworkConditions', {
+    offline: false,
+    latency,
+    downloadThroughput: 1.5 * 1024 * 1024 / 8,
+    uploadThroughput: 750 * 1024 / 8,
+  });
+
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+
+  // Overlay phase screenshot (best effort — it may already be dismissing)
+  try {
+    await page.waitForSelector('text=Cluster Dashboard', { timeout: 4000 });
+    await page.screenshot({ path: path.join(outDir, 'progressive-loading-overlay.png') });
+    console.log('📸 Overlay phase captured');
+  } catch (e) {
+    console.log('ℹ️  Overlay dismissed before capture (fast network)');
+  }
+
+  // Wait for the grid to be interactive, then capture the loaded state
+  await page.waitForTimeout(duration);
+  await page.screenshot({ path: path.join(outDir, 'progressive-loading-loaded.png') });
+  console.log('📸 Loaded dashboard captured');
+
+  await context.close(); // flushes the video
+  await browser.close();
+
+  // Rename playwright's random video filename to something stable
+  const vids = fs.readdirSync(outDir).filter((f) => f.endsWith('.webm') && f !== 'progressive-loading.webm');
+  if (vids.length > 0) {
+    const newest = vids
+      .map((f) => ({ f, t: fs.statSync(path.join(outDir, f)).mtimeMs }))
+      .sort((a, b) => b.t - a.t)[0].f;
+    fs.copyFileSync(path.join(outDir, newest), path.join(outDir, 'progressive-loading.webm'));
+    fs.unlinkSync(path.join(outDir, newest));
+  }
+
+  console.log('✅ Artifacts:');
+  console.log(`   ${path.join(outDir, 'progressive-loading.webm')}`);
+  console.log(`   ${path.join(outDir, 'progressive-loading-loaded.png')}`);
+}
+
+main().catch((err) => {
+  console.error('❌ Recording failed:', err.message);
+  process.exit(1);
+});

--- a/scripts/start-lan-game.sh
+++ b/scripts/start-lan-game.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# ============================================================================
+# start-lan-game.sh — one command from zero to an active Lego Loco LAN game
+# ============================================================================
+# Brings the cluster up, deploys the 2-instance LAN configuration, drives
+# both Win98 guests into a multiplayer session via QMP, and captures proof
+# artifacts (guest screendumps + optional dashboard loading video).
+#
+# Usage:
+#   scripts/start-lan-game.sh [options]
+#
+# Options:
+#   --cluster NAME     kind cluster name (default: loco)
+#   --namespace NS     kubernetes namespace (default: loco)
+#   --values FILE      helm values overlay (default: helm/loco-chart/values-lan-test.yaml)
+#   --proof-dir DIR    where proof artifacts land (default: proof/lan-game-<timestamp>)
+#   --skip-cluster     assume the cluster and images already exist
+#   --skip-build       do not rebuild backend/frontend images
+#   --skip-game        deploy + wait only; skip the in-game QMP choreography
+#   --record           also record the dashboard's progressive loading (playwright)
+#
+# Requires: docker, kind, kubectl, helm, python3. Playwright only with --record.
+# The in-game choreography needs the emulator image whose guests were baked
+# network-ready (see docs/LAN_MULTIPLAYER_AND_GHCR_RUNBOOK.md).
+# ============================================================================
+set -euo pipefail
+
+CLUSTER=loco
+NAMESPACE=loco
+VALUES=helm/loco-chart/values-lan-test.yaml
+PROOF_DIR=""
+SKIP_CLUSTER=false
+SKIP_BUILD=false
+SKIP_GAME=false
+RECORD=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --cluster) CLUSTER="$2"; shift 2;;
+    --namespace) NAMESPACE="$2"; shift 2;;
+    --values) VALUES="$2"; shift 2;;
+    --proof-dir) PROOF_DIR="$2"; shift 2;;
+    --skip-cluster) SKIP_CLUSTER=true; shift;;
+    --skip-build) SKIP_BUILD=true; shift;;
+    --skip-game) SKIP_GAME=true; shift;;
+    --record) RECORD=true; shift;;
+    *) echo "Unknown option: $1" >&2; exit 2;;
+  esac
+done
+
+STAMP=$(date +%Y%m%d-%H%M%S)
+PROOF_DIR=${PROOF_DIR:-proof/lan-game-$STAMP}
+mkdir -p "$PROOF_DIR"
+LOG="$PROOF_DIR/start-lan-game.log"
+
+log() { echo "[$(date +'%H:%M:%S')] $*" | tee -a "$LOG"; }
+
+log "=== Lego Loco LAN game quickstart ==="
+log "cluster=$CLUSTER namespace=$NAMESPACE values=$VALUES proof=$PROOF_DIR"
+
+# ---------------------------------------------------------------------------
+# 1. Cluster
+# ---------------------------------------------------------------------------
+if [ "$SKIP_CLUSTER" != true ]; then
+  if ! kind get clusters 2>/dev/null | grep -qx "$CLUSTER"; then
+    log "Creating kind cluster '$CLUSTER'..."
+    kind create cluster --name "$CLUSTER" --wait 180s
+  else
+    log "kind cluster '$CLUSTER' already exists"
+  fi
+fi
+KCTX="kind-$CLUSTER"
+kubectl config use-context "$KCTX" >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------
+# 2. Images
+# ---------------------------------------------------------------------------
+if [ "$SKIP_BUILD" != true ]; then
+  log "Building backend image (context is allowlisted — see .dockerignore)..."
+  docker build -f backend/Dockerfile --target production -t lego-loco-backend:local . >>"$LOG" 2>&1
+  log "Building frontend image..."
+  docker build -f frontend/Dockerfile --target production -t lego-loco-frontend:local ./frontend >>"$LOG" 2>&1
+  log "Loading app images into kind..."
+  kind load docker-image lego-loco-backend:local --name "$CLUSTER" >>"$LOG" 2>&1
+  kind load docker-image lego-loco-frontend:local --name "$CLUSTER" >>"$LOG" 2>&1
+fi
+
+EMU_IMAGE=$(grep -A2 '^emulator:' "$VALUES" | grep 'image:' | awk '{print $2}')
+EMU_TAG=$(grep -A3 '^emulator:' "$VALUES" | grep 'tag:' | awk '{print $2}')
+if ! docker exec "${CLUSTER}-control-plane" crictl images 2>/dev/null | grep -q "$EMU_IMAGE"; then
+  if docker image inspect "$EMU_IMAGE:$EMU_TAG" >/dev/null 2>&1; then
+    log "Loading emulator image $EMU_IMAGE:$EMU_TAG into kind (large, one-time)..."
+    kind load docker-image "$EMU_IMAGE:$EMU_TAG" --name "$CLUSTER" >>"$LOG" 2>&1
+  else
+    log "WARNING: emulator image $EMU_IMAGE:$EMU_TAG not present locally."
+    log "         Build it per docs/LAN_MULTIPLAYER_AND_GHCR_RUNBOOK.md §2.1 first."
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Deploy
+# ---------------------------------------------------------------------------
+kubectl get namespace "$NAMESPACE" >/dev/null 2>&1 || kubectl create namespace "$NAMESPACE"
+log "Deploying helm release..."
+helm upgrade --install loco helm/loco-chart -n "$NAMESPACE" -f "$VALUES" --wait --timeout 10m >>"$LOG" 2>&1
+
+log "Waiting for emulator pods to be Ready..."
+kubectl rollout status statefulset/loco-loco-emulator -n "$NAMESPACE" --timeout=15m >>"$LOG" 2>&1
+
+PODS=$(kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/component=emulator -o name)
+log "Emulator pods: $(echo "$PODS" | tr '\n' ' ')"
+
+# ---------------------------------------------------------------------------
+# 4. Dashboard access + optional progressive-loading recording
+# ---------------------------------------------------------------------------
+log "Port-forwarding frontend to http://localhost:3000 (background)..."
+pkill -f "port-forward.*loco-loco-frontend" 2>/dev/null || true
+kubectl port-forward -n "$NAMESPACE" svc/loco-loco-frontend 3000:3000 >>"$LOG" 2>&1 &
+PF_PID=$!
+sleep 3
+
+if [ "$RECORD" = true ]; then
+  log "Recording progressive loading (playwright)..."
+  node scripts/record-progressive-loading.js --url http://localhost:3000 --out "$PROOF_DIR" >>"$LOG" 2>&1 \
+    && log "Dashboard recording saved to $PROOF_DIR" \
+    || log "WARNING: dashboard recording failed (is playwright installed?)"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. In-game LAN session
+# ---------------------------------------------------------------------------
+if [ "$SKIP_GAME" != true ]; then
+  log "Driving guests into a LAN game (QMP choreography)..."
+  python3 scripts/lan-game-steps.py \
+    --namespace "$NAMESPACE" \
+    --proof-dir "$PROOF_DIR" \
+    --host-steps scripts/lan-game-steps/host-create.steps \
+    --guest-steps scripts/lan-game-steps/guest-join.steps 2>&1 | tee -a "$LOG"
+fi
+
+log ""
+log "=== Done ==="
+log "Dashboard:   http://localhost:3000 (port-forward pid $PF_PID)"
+log "Proofs:      $PROOF_DIR"
+log "Direct VNC:  kubectl port-forward -n $NAMESPACE loco-loco-emulator-0 5901:5901"


### PR DESCRIPTION
Adds an easy path from zero to an active Lego Loco LAN game, plus proof capture, as requested after the salvage work.

## What's new
- **`scripts/start-lan-game.sh`** — creates/reuses the kind cluster, builds and loads app images (backend context is now ~223 kB thanks to #96), deploys the 2-instance LAN overlay, waits for readiness, port-forwards the dashboard, optionally records progressive loading, and drives both guests into a TCP multiplayer game. Flags: `--skip-cluster/--skip-build/--skip-game/--record`.
- **`scripts/lan-game-steps.py`** + **`scripts/lan-game-steps/*.steps`** — a data-driven QMP step runner (`hmp`/`loadvm`/`sleep`/`dump`) and the host-create / guest-join choreography recorded from the LAN runbook §2.4.
- **`scripts/record-progressive-loading.js`** — playwright recorder that throttles the network so both phases of the new loading overlay are visible on video.
- **helm fix**: dropped `StatefulSet.updateStrategy.rollingUpdate.maxUnavailable`, which fails `helm upgrade` validation on k8s <1.24 (Docker Desktop 1.19, kind 1.27) — this was blocking the LAN deploy.
- **runbook**: documented the one-command flow.

## Verified live
Deployed the 2-instance LAN config on Docker Desktop k8s with the post-salvage images; both Win98 guests boot network-ready (RTL8029 NIC), and the progressive-loading overlay → grid transition was recorded on video. Proof artifacts on branch [`evidence/quickstart-2026-07-06`](https://github.com/MRoie/lego-loco-cluster/tree/evidence/quickstart-2026-07-06/evidence).

**In-game caveat**: the full `--skip-game`-off choreography needs the emulator image baked to a `mainmenu` savevm (runbook §2.5). The local `lan-test-flat` image is pre-bake, so its guests boot into the NIC driver wizard and the step runner's `loadvm` degrades gracefully. Bake + push a netready snapshot to run the in-game phase end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)